### PR TITLE
fix warnings for backend gulp task remap:coverage

### DIFF
--- a/api/gulpfile.js
+++ b/api/gulpfile.js
@@ -115,7 +115,7 @@ gulp.task(REMAP_COVERAGE, function() {
             fail: true,
             reports: {
                 "html": "./coverage",
-                "json": "./coverage",
+                "json": "./coverage/coverage-report.json",
                 "text-summary": null,
                 "lcovonly": "./coverage/lcov.info"
             }


### PR DESCRIPTION
``(node:5304) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 2): Error: EISDIR: illegal operation on a directory, open '/home/travis/build/h-da/geli/api/coverage'
(node:5304) DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.``

This commit fixes the warnings by selecting a file instead of a directory for the remapped json file:
```json
remapIstanbul({
            // basePath: ".",
            fail: true,
            reports: {
                "html": "./coverage",
                "json": "./coverage/coverage-report.json",
                "text-summary": null,
                "lcovonly": "./coverage/lcov.info"
            }
        })
```