### PR TITLE
Unignores JS-Files in Sub-Project-Roots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ testem.log
 .DS_Store
 Thumbs.db
 *.js
+# Do not ignore js files under sub-project-root (gulpfile.js, karma.conf.js, protractor.conf.js, ...)
+!/api/*.js
+!/app/webFrontend/*.js


### PR DESCRIPTION
# Request Title:
Unignores JS-Files in Sub-Project-Roots

## Description:
This PR excludes the files `api/*.js` and `app/webFrontend/*.js` from gitignore so `karma` conf and stuff like that isn't "excluded but tracket" anymore.

## Improvements
- corrects .gitignore

## Known Issues:

