### PR TITLE
Bugfix/material module for root

### DIFF
--- a/app/webFrontend/src/app/shared/modules/dialog/dialog.module.ts
+++ b/app/webFrontend/src/app/shared/modules/dialog/dialog.module.ts
@@ -1,11 +1,9 @@
 import { NgModule } from '@angular/core';
-import { MaterialModule } from '@angular/material';
 import {ConfirmDialog} from '../../components/delete-dialog/confirm-dialog.component';
 import {DialogService} from '../../services/dialog.service';
 
 @NgModule({
   imports: [
-    MaterialModule.forRoot()
   ],
   exports: [
     ConfirmDialog

--- a/app/webFrontend/src/app/shared/modules/dialog/dialog.module.ts
+++ b/app/webFrontend/src/app/shared/modules/dialog/dialog.module.ts
@@ -1,9 +1,11 @@
 import { NgModule } from '@angular/core';
+import {MaterialModule} from '@angular/material';
 import {ConfirmDialog} from '../../components/delete-dialog/confirm-dialog.component';
 import {DialogService} from '../../services/dialog.service';
 
 @NgModule({
   imports: [
+    MaterialModule
   ],
   exports: [
     ConfirmDialog

--- a/app/webFrontend/src/app/shared/modules/dialog/dialog.module.ts
+++ b/app/webFrontend/src/app/shared/modules/dialog/dialog.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import {MaterialModule} from '@angular/material';
+import { MaterialModule } from '@angular/material';
 import {ConfirmDialog} from '../../components/delete-dialog/confirm-dialog.component';
 import {DialogService} from '../../services/dialog.service';
 


### PR DESCRIPTION
# Request Title:
Removes Deprecated call

## Description:
**PLEASE CHECK THIS CHANGE BEFORE MERGE!!!**

https://github.com/angular/material2/blob/6121fa18babd70cffc680b9cd2b6ade8edb9ae32/CHANGELOG.md#200-beta4-unobtainium-sunglasses-2017-05-12

Removes call to `forRoot()`, found example: https://github.com/angular/material2/blob/6121fa18babd70cffc680b9cd2b6ade8edb9ae32/CHANGELOG.md#200-beta2-flannel-papaya-2017-02-15

## Improvements
Removes the Error on `ng e2e`:
```
ERROR in /vagrant/app/webFrontend/src/app/shared/modules/dialog/dialog.module.ts (8,20): Property 'forRoot' does not exist on type 'typeof MaterialModule'.

ERROR in Error encountered resolving symbol values statically. Calling function 'MaterialModule', function calls are not supported. Consider replacing the function or lambda with a reference to an exported function, resolving symbol DialogModule in /vagrant/app/webFrontend/src/app/shared/modules/dialog/dialog.module.ts, resolving symbol DialogModule in /vagrant/app/webFrontend/src/app/shared/modules/dialog/dialog.module.ts
webpack: Failed to compile.
```

## Known Issues:

