### PR TITLE
Add preparation for whitelist, set difficult usernames because there …

### DIFF
--- a/api/fixtures/userFixtures.ts
+++ b/api/fixtures/userFixtures.ts
@@ -5,6 +5,7 @@ export const userFixtures: IFixture = {
   Model: User,
   data: [
     {
+      username: 'TStud1',
       email: 'student1@test.local',
       password: 'test',
       profile: {
@@ -14,6 +15,7 @@ export const userFixtures: IFixture = {
       isActive: true
     },
     {
+      username: 'TStud2',
       email: 'student2@test.local',
       password: 'test',
       profile: {
@@ -23,6 +25,7 @@ export const userFixtures: IFixture = {
       isActive: true
     },
     {
+      username: 'TStud3',
       email: 'student3@test.local',
       password: 'test',
       profile: {
@@ -32,6 +35,7 @@ export const userFixtures: IFixture = {
       isActive: true
     },
     {
+      username: 'DAdmin',
       email: 'admin@test.local',
       password: 'test',
       role: 'admin',
@@ -42,6 +46,7 @@ export const userFixtures: IFixture = {
       isActive: true
     },
     {
+      username: 'DTeach',
       email: 'teacher@test.local',
       password: 'test',
       role: 'teacher',

--- a/api/src/models/Course.ts
+++ b/api/src/models/Course.ts
@@ -36,11 +36,22 @@ const courseSchema = new mongoose.Schema({
         ref: 'Lecture'
       }
     ],
+    enrollType: {
+      type: String,
+      'enum': ['free', 'whitelist'],
+      'default': 'free'
+    },
+    whitelist: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'User'
+      }
+    ]
   },
   {
     timestamps: true,
     toObject: {
-      transform: function(doc: any, ret: any) {
+      transform: function (doc: any, ret: any) {
         ret._id = ret._id.toString();
       }
     }


### PR DESCRIPTION
…are unique and should not be all null

# Request Title:

## Description:
Preparation for ne releaser where we need a whitelist, so we have more than one option to entroll in a course.
Fixtures are not load in monoDB because there all have username null and it is a unique field.

## Improvements


## Known Issues:

