### PR TITLE
GULP-API-Task-Improvement

### DIFF
--- a/api/gulpfile.js
+++ b/api/gulpfile.js
@@ -101,7 +101,7 @@ gulp.task(GENERATE_DOC, [CLEAN_DOC], function () {
       readme: "readme.md",
       version: true,
       module: "commonjs"
-    }))
+    }));
 });
 
 // Sets up the istanbul coverage
@@ -175,7 +175,7 @@ gulp.task(WATCH_POLL, [BUILD_DEV], function () {
 });
 
 gulp.task(LOAD_FIXTURES, [BUILD], function () {
-  require(__dirname + '/build/fixtures/load');
+  require(__dirname + "/build/fixtures/load");
 });
 
 gulp.task(DEBUG, [BUILD_DEV], function () {

--- a/api/gulpfile.js
+++ b/api/gulpfile.js
@@ -16,14 +16,19 @@ const CLEAN_BUILD = "clean:build";
 const CLEAN_COVERAGE = "clean:coverage";
 const CLEAN_DOC = "clean:doc";
 const TSLINT = "tslint";
+const TSLINT_DEV = "tslint:dev";
 const COMPILE_TYPESCRIPT = "compile:typescript";
 const BUILD = "build";
+const BUILD_DEV = "build:dev";
 const GENERATE_DOC = "generate:doc";
 const PRETEST = "pretest";
 const RUN_TESTS = "run:tests";
 const LOAD_FIXTURES = "load:fixtures";
 const TEST = "test";
 const REMAP_COVERAGE = "remap:coverage";
+const WATCH = "watch";
+const WATCH_POLL = "watch:poll";
+const DEBUG = "debug";
 
 const TS_SRC_GLOB = "./src/**/*.ts";
 const TS_TEST_GLOB = "./test/**/*.ts";
@@ -35,124 +40,150 @@ const TS_GLOB = [TS_SRC_GLOB, TS_TEST_GLOB, TS_FIXTURES_GLOB];
 const tsProject = typescript.createProject("tsconfig.json");
 
 // Removes the ./build directory with all its content.
-gulp.task(CLEAN_BUILD, function(callback) {
-    rimraf("./build", callback);
+gulp.task(CLEAN_BUILD, function (callback) {
+  rimraf("./build", callback);
 });
 
 // Removes the ./coverage directory with all its content.
-gulp.task(CLEAN_COVERAGE, function(callback) {
-    rimraf("./coverage", callback);
+gulp.task(CLEAN_COVERAGE, function (callback) {
+  rimraf("./coverage", callback);
 });
 
 // Removes the ./docs directory with all its content.
-gulp.task(CLEAN_DOC, function(callback) {
-    rimraf("./docs", callback);
+gulp.task(CLEAN_DOC, function (callback) {
+  rimraf("./docs", callback);
 });
 
 // Checks all *.ts-files if they are conform to the rules specified in tslint.json.
-gulp.task(TSLINT, function() {
-    return gulp.src(TS_GLOB)
-        .pipe(tslint({formatter: "verbose"}))
-        .pipe(tslint.report({
-            // set this to true, if you want the build process to fail on tslint errors.
-            emitError: true
-        }));
+gulp.task(TSLINT, function () {
+  return gulp.src(TS_GLOB)
+    .pipe(tslint({formatter: "verbose"}))
+    .pipe(tslint.report({
+      // set this to true, if you want the build process to fail on tslint errors.
+      emitError: true
+    }));
+});
+
+// Checks all *.ts-files if they are conform to the rules specified in tslint.json. WON'T ERROR ON LINTING ERROR.
+gulp.task(TSLINT_DEV, function () {
+  return gulp.src(TS_GLOB)
+    .pipe(tslint({formatter: "verbose"}))
+    .pipe(tslint.report({
+      // set this to true, if you want the build process to fail on tslint errors.
+      emitError: false
+    }));
 });
 
 // Compiles all *.ts-files to *.js-files.
-gulp.task(COMPILE_TYPESCRIPT, function() {
-    return gulp.src(TS_GLOB, {base: "."})
-        .pipe(sourcemaps.init())
-        .pipe(tsProject())
-        .pipe(sourcemaps.write())
-        .pipe(gulp.dest("./build"));
+gulp.task(COMPILE_TYPESCRIPT, function () {
+  return gulp.src(TS_GLOB, {base: "."})
+    .pipe(sourcemaps.init())
+    .pipe(tsProject())
+    .pipe(sourcemaps.write())
+    .pipe(gulp.dest("./build"));
 });
 
 // Runs all required steps for the build in sequence.
-gulp.task(BUILD, function(callback) {
-    runSequence(CLEAN_BUILD, TSLINT, COMPILE_TYPESCRIPT, callback);
+gulp.task(BUILD, function (callback) {
+  runSequence(CLEAN_BUILD, TSLINT, COMPILE_TYPESCRIPT, callback);
+});
+
+// Runs all required steps for the build in sequence FOR DEVELOP
+gulp.task(BUILD_DEV, function (callback) {
+  runSequence(CLEAN_BUILD, TSLINT_DEV, COMPILE_TYPESCRIPT, callback);
 });
 
 // Generates a documentation based on the code comments in the *.ts files.
-gulp.task(GENERATE_DOC, [CLEAN_DOC], function() {
-    return gulp.src(TS_SRC_GLOB)
-        .pipe(typedoc({
-            out: "./docs",
-            readme: "readme.md",
-            version: true,
-            module: "commonjs"
-        }))
+gulp.task(GENERATE_DOC, [CLEAN_DOC], function () {
+  return gulp.src(TS_SRC_GLOB)
+    .pipe(typedoc({
+      out: "./docs",
+      readme: "readme.md",
+      version: true,
+      module: "commonjs"
+    }))
 });
 
 // Sets up the istanbul coverage
-gulp.task(PRETEST, function() {
-    gulp.src(JS_SRC_GLOB)
-        .pipe(sourcemaps.init({loadMaps: true}))
-        .pipe(istanbul({includeUntested: true}))
-        .pipe(istanbul.hookRequire())
+gulp.task(PRETEST, function () {
+  gulp.src(JS_SRC_GLOB)
+    .pipe(sourcemaps.init({loadMaps: true}))
+    .pipe(istanbul({includeUntested: true}))
+    .pipe(istanbul.hookRequire())
 });
 
 // Run the tests via mocha and generate a istanbul json report.
-gulp.task(RUN_TESTS, function(callback) {
-    let mochaError;
-    gulp.src(JS_TEST_GLOB)
-        .pipe(plumber())
-        .pipe(mocha({reporter: "spec"}))
-        .on("error", function(err) {
-            mochaError = err;
-        })
-        .pipe(istanbul.writeReports({
-            reporters: ["json"]
-        }))
-        .on("end", function() {
-            callback(mochaError);
-        });
+gulp.task(RUN_TESTS, function (callback) {
+  let mochaError;
+  gulp.src(JS_TEST_GLOB)
+    .pipe(plumber())
+    .pipe(mocha({reporter: "spec"}))
+    .on("error", function (err) {
+      mochaError = err;
+    })
+    .pipe(istanbul.writeReports({
+      reporters: ["json"]
+    }))
+    .on("end", function () {
+      callback(mochaError);
+    });
 });
 
 // Remap Coverage to *.ts-files and generate html, text and json summary
-gulp.task(REMAP_COVERAGE, function() {
-    return gulp.src("./coverage/coverage-final.json")
-        .pipe(remapIstanbul({
-            // basePath: ".",
-            fail: true,
-            reports: {
-                "html": "./coverage",
-                "json": "./coverage/coverage-report.json",
-                "text-summary": null,
-                "lcovonly": "./coverage/lcov.info"
-            }
-        }))
-        .pipe(gulp.dest("coverage"))
-        .on("end", function() {
-            console.log("--> For a more detailed report, check the ./coverage directory <--")
-        });
+gulp.task(REMAP_COVERAGE, function () {
+  return gulp.src("./coverage/coverage-final.json")
+    .pipe(remapIstanbul({
+      // basePath: ".",
+      fail: true,
+      reports: {
+        "html": "./coverage",
+        "json": "./coverage/coverage-report.json",
+        "text-summary": null,
+        "lcovonly": "./coverage/lcov.info"
+      }
+    }))
+    .pipe(gulp.dest("coverage"))
+    .on("end", function () {
+      console.log("--> For a more detailed report, check the ./coverage directory <--")
+    });
 });
 
 // Runs all required steps for testing in sequence.
-gulp.task(TEST, function(callback) {
-    runSequence(BUILD, CLEAN_COVERAGE, PRETEST, RUN_TESTS, REMAP_COVERAGE, callback);
+gulp.task(TEST, function (callback) {
+  runSequence(BUILD, CLEAN_COVERAGE, PRETEST, RUN_TESTS, REMAP_COVERAGE, callback);
 });
 
 // Runs the build task and starts the server every time changes are detected.
-gulp.task("watch", [BUILD], function() {
-    return nodemon({
-        ext: "ts js json",
-        script: "build/src/server.js",
-        watch: ["src/*", "test/*"],
-        tasks: [BUILD]
-    });
+gulp.task(WATCH, [BUILD_DEV], function () {
+  return nodemon({
+    ext: "ts js json",
+    script: "build/src/server.js",
+    watch: ["src/*", "test/*"],
+    tasks: [BUILD_DEV]
+  });
+});
+
+// Runs the build task and starts the server every time changes are detected WITH LEGACY-WATCH ENABLED.
+gulp.task(WATCH_POLL, [BUILD_DEV], function () {
+  return nodemon({
+    ext: "ts js json",
+    script: "build/src/server.js",
+    watch: ["src/*", "test/*"],
+    legacyWatch: true, // Uses the legacy polling to get changes even on docker/vagrant-mounts
+    tasks: [BUILD_DEV]
+  });
 });
 
 gulp.task(LOAD_FIXTURES, [BUILD], function () {
   require(__dirname + '/build/fixtures/load');
 });
 
-gulp.task("debug", [BUILD], function () {
+gulp.task(DEBUG, [BUILD_DEV], function () {
   return nodemon({
     ext: "ts js json",
     script: "build/src/server.js",
     watch: ["src/*", "test/*"],
-    tasks: [BUILD],
+    tasks: [BUILD_DEV],
     nodeArgs: ["--debug-brk=9000"]
   });
 });

--- a/api/package.json
+++ b/api/package.json
@@ -18,6 +18,7 @@
     "build": "gulp build",
     "doc": "gulp generate:doc",
     "start": "gulp watch",
+    "start:poll": "gulp watch:poll",
     "test": "gulp test",
     "tslint": "gulp tslint",
     "debug": "gulp debug",

--- a/app/webFrontend/package.json
+++ b/app/webFrontend/package.json
@@ -12,7 +12,7 @@
     "ng": "ng",
     "start": "ng serve --proxy-config local-proxy.conf.json",
     "start-docker-dev": "ng serve --host 0.0.0.0 --proxy-config docker-proxy.conf.json",
-    "start-vagrant-dev": "ng serve --host 0.0.0.0 --proxy-config local-proxy.conf.json",
+    "start-vagrant-dev": "ng serve --host 0.0.0.0 --proxy-config local-proxy.conf.json --poll 500",
     "build": "ng build --prod",
     "test": "ng test",
     "lint": "ng lint",


### PR DESCRIPTION
# Request Title:
Adds polling mode and no break through linting

## Description:
This PR adds a Polling mode for BE and FE. 
In addition BE linting failures will not stop the server from compiling and serving the content.

## Improvements
- Adds `watch:poll`-gulp task
- Adds `build:dev`-gulp tasl
- Adds polling to vagrant start on FE
- Puts all gulp-task-names in constants

## Known Issues:

