### PR TITLE
Adds license.josn to docker

### DIFF
--- a/.docker/api/Dockerfile
+++ b/.docker/api/Dockerfile
@@ -11,3 +11,4 @@ CMD node server.js
 
 COPY api/build/src /usr/src/app/
 COPY api/node_modules /usr/src/app/node_modules
+COPY api/nlf-licenses.json /usr/src/app/


### PR DESCRIPTION
# Request Title:


## Description:
- Adds the API-License-json to the docker image

## Improvements


## Known Issues:

