### PR TITLE
Adds a access log constraint by useragent

### DIFF
--- a/.docker/web-frontend/Dockerfile
+++ b/.docker/web-frontend/Dockerfile
@@ -4,5 +4,6 @@ FROM nginx:1.13
 RUN rm /etc/nginx/conf.d/default.conf
 
 COPY .docker/web-frontend/project.conf /etc/nginx/conf.d/project.conf
+COPY .docker/web-frontend/map_ua.conf /etc/nginx/conf.d/map_ua.conf
 
 COPY app/webFrontend/dist /var/www/dist

--- a/.docker/web-frontend/map_ua.conf
+++ b/.docker/web-frontend/map_ua.conf
@@ -1,0 +1,8 @@
+# Decide if useragent should be logged or not
+map $http_user_agent $log_ua {
+  # This is a exmaple config to ignore the useragent from uptimerobot.com
+  # ~*UptimeRobot 0;
+
+  # Everything else will be access_logged
+  default 1;
+}

--- a/.docker/web-frontend/project.conf
+++ b/.docker/web-frontend/project.conf
@@ -13,4 +13,8 @@ server {
     }
 
     server_tokens off;
+
+    # This requires a mapping from useragents to the var log_ua
+    # We have done this by mounting the file map_ua.conf to /etc/nginx/conf.d/
+    access_log  /var/log/nginx/access.log combined if=$log_ua;
 }


### PR DESCRIPTION
# Request Title:


## Description:
This line of Nginx-Config should log to the access log only if the useragent of the client is allowed. This will prevent to fill the logs withcalls from eg uptimerobot. I have testet on the reverse-proxy and edited the currently running image of the geli-staging-frontend.

Don't worry about the log-path, it is the default path. It is symlinked to stdout:
```
root@d2a76559bd3b:/# ls -la /var/log/nginx/
total 8
drwxr-xr-x 1 root root 4096 May 30 17:09 .
drwxr-xr-x 1 root root 4096 May 30 17:09 ..
lrwxrwxrwx 1 root root   11 May 30 17:09 access.log -> /dev/stdout
lrwxrwxrwx 1 root root   11 May 30 17:09 error.log -> /dev/stderr
```

This PR resolves no specific issue.

## Improvements


## Known Issues:

