### PR TITLE
remove uneccessary extends

### DIFF
--- a/api/src/controllers/CodeKataProgressController.ts
+++ b/api/src/controllers/CodeKataProgressController.ts
@@ -8,7 +8,7 @@ import {ICodeKataProgress} from '../../../shared/models/ICodeKataProgress';
 
 @JsonController('/progress/code-katas')
 @UseBefore(passportJwtMiddleware)
-export class CodeKataProgressController extends ProgressController {
+export class CodeKataProgressController {
   @Post('/')
   createProgress(@Body() data: any) {
     // discard invalid requests


### PR DESCRIPTION
rempves unneccessary extend in CodeKataProgressController

```
src/controllers/CodeKataProgressController.ts(11,14): error TS2415: Class 'CodeKataProgressController' incorrectly extends base class 'ProgressController'.
  Types of property 'createProgress' are incompatible.
    Type '(data: any) => BadRequestError | Promise<Document>' is not assignable to type '(data: any, currentUser?: IUser) => Promise<Object>'.
      Type 'BadRequestError | Promise<Document>' is not assignable to type 'Promise<Object>'.
        Type 'BadRequestError' is not assignable to type 'Promise<Object>'.
          Property 'then' is missing in type 'BadRequestError'.
```