### PR TITLE
fixes issue #168 Tagged Builds do not push a image to docker

### DIFF
--- a/.travis/docker.sh
+++ b/.travis/docker.sh
@@ -25,7 +25,7 @@ if [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "develop" ]; then
     echo -e "${YELLOW}+ WARNING: pull request #$TRAVIS_PULL_REQUEST -> skipping docker build and publish${NC}";
   fi
 else
-  if [ "$TRAVIS_BRANCH" == "$TRAVIS_TAG" ]; then
+  if [ -n "$TRAVIS_TAG" ]; then
     echo "+ This is a tagged build: $TRAVIS_TAG";
     echo "+ build docker images";
     echo "+ prune dev-dependencies"

--- a/.travis/docker.sh
+++ b/.travis/docker.sh
@@ -25,7 +25,7 @@ if [ "$TRAVIS_BRANCH" == "master" ] || [ "$TRAVIS_BRANCH" == "develop" ]; then
     echo -e "${YELLOW}+ WARNING: pull request #$TRAVIS_PULL_REQUEST -> skipping docker build and publish${NC}";
   fi
 else
-  if [ -z ${TRAVIS_TAG+x}  ]; then
+  if [ "$TRAVIS_BRANCH" == "$TRAVIS_TAG" ]; then
     echo "+ This is a tagged build: $TRAVIS_TAG";
     echo "+ build docker images";
     echo "+ prune dev-dependencies"


### PR DESCRIPTION
If the build isn't triggered trough a TAG the env TRAVIS_TAG is empty or not set.
So if the TRAVIS_TAG matches the TRAVIS_BRANCH this indicates a tagged build which should end in a tagged image on the docker hub