### PR TITLE
refactor restricting default value

### DIFF
--- a/api/src/config/main.ts
+++ b/api/src/config/main.ts
@@ -22,5 +22,5 @@ export default {
     pass: process.env.MAILPASS || ''
   },
   mailSender: process.env.MAILSENDER || 'no-reply@geli.edu',
-  teacherMailRegex: process.env.TEACHER_MAIL_REGEX || '$',
+  teacherMailRegex: process.env.TEACHER_MAIL_REGEX || '^.+@.+$',
 };

--- a/api/src/config/main.ts
+++ b/api/src/config/main.ts
@@ -22,5 +22,5 @@ export default {
     pass: process.env.MAILPASS || ''
   },
   mailSender: process.env.MAILSENDER || 'no-reply@geli.edu',
-  teacherMailRegex: process.env.TEACHER_MAIL_REGEX || '@h-da.de$',
+  teacherMailRegex: process.env.TEACHER_MAIL_REGEX || '$',
 };

--- a/api/src/config/main.ts
+++ b/api/src/config/main.ts
@@ -22,5 +22,5 @@ export default {
     pass: process.env.MAILPASS || ''
   },
   mailSender: process.env.MAILSENDER || 'no-reply@geli.edu',
-  teacherMailRegex: process.env.TEACHER_MAIL_REGEX || '^.+@.+$',
+  teacherMailRegex: process.env.TEACHER_MAIL_REGEX || '^.+@.+\..+$',
 };


### PR DESCRIPTION
refactors restricting `TEACHER_MAIL_REGEX` to `$` to avoid trouble mentioned in #217 (closes #217) 

