### PR TITLE
Remove call to coveralls to prevent unfinished checkups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ script:
 
 after_script:
   # send required files to coveralls.io
-  - .travis/coveralls.sh
+  # - .travis/coveralls.sh
 
 after_success:
   - .travis/package-checker.sh


### PR DESCRIPTION
# Request Title:


## Description:
Removes call to coveralls.sh to prevent unfinished merge checks.

## Improvements
Coveralls check doesn't run.

## Known Issues:
None.
