### PR TITLE
Bugfix/coveralls 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,7 +82,7 @@ script:
 
 after_script:
   # send required files to coveralls.io
-  # - .travis/coveralls.sh
+  - .travis/coveralls.sh
 
 after_success:
   - .travis/package-checker.sh

--- a/.travis/coveralls.sh
+++ b/.travis/coveralls.sh
@@ -30,8 +30,10 @@ fi
 cd ..
 
 echo "+ sending lcov file to coveralls"
-sed -i 's/bin\///g' api/coverage/lcov.info && cat api/coverage/lcov.info | $MODULE_PATH/$BIN_PATH/coveralls
-# cat api/coverage/lcov.info | $MODULE_PATH/$BIN_PATH/coveralls.js -v
+# since we are using typescript and remap our coverage data to the ts files we need to remove the "build" part of all paths
+# this could easily be done with some sed magic
+# search for "api/build/src" and replace it with "api/src"
+sed "s/api\/build\/src/api\/src/g" api/coverage/lcov.info | $MODULE_PATH/$BIN_PATH/coveralls -v
 
 echo "+ INFO: Currently only the api-coverdata are generated and send"
 


### PR DESCRIPTION
## Description:
It took me some deep debuging but i finally found our problem with coveralls.io
https://coveralls.io/github/khase/geli

Closes #228 

remapIstanbul remaps our coverage Data to its corresponding .ts files (in fact it tries to)
but this module fails to remap the whole path in the .lcov file.

this pr fixes this with a sed call before passing the .lcov to coveralls

```
sed "s/api\/build\/src/api\/src/g" api/coverage/lcov.info
```

## Improvements
activates coveralls for travis builds

## Known Issues:
none
