### PR TITLE
Now using maxWidth for Dialog via config, removes css-hack

### DIFF
--- a/app/webFrontend/src/_global-hacks.scss
+++ b/app/webFrontend/src/_global-hacks.scss
@@ -1,5 +1,2 @@
 // With a material update we can disable this hack
 // see app/webFrontend/src/app/unit/unit-form/free-text-unit-form/free-text-unit-form.component.ts:78
-.mat-dialog-container {
-  max-width: 100vw!important;
-}

--- a/app/webFrontend/src/_global-hacks.scss
+++ b/app/webFrontend/src/_global-hacks.scss
@@ -1,2 +1,0 @@
-// With a material update we can disable this hack
-// see app/webFrontend/src/app/unit/unit-form/free-text-unit-form/free-text-unit-form.component.ts:78

--- a/app/webFrontend/src/app/unit/unit-form/free-text-unit-form/free-text-unit-form.component.ts
+++ b/app/webFrontend/src/app/unit/unit-form/free-text-unit-form/free-text-unit-form.component.ts
@@ -75,12 +75,11 @@ export class FreeTextUnitFormComponent implements OnInit {
   }
 
   openFullscreen(): void {
-    // TODO: Max-Width/-Height comes with later Material version
-    // maxWidth: '100vw',
-    // maxHeight: '100vh',
     const dialogRef = this.dialog.open(FreeTextUnitEditorDialog, {
       width: '94vw',
       height: '94vh',
+      maxWidth: '100vw',
+      maxHeight: '100vh',
       data: {
         markdown: this.freeTextEditor.markdown ? this.freeTextEditor.markdown : ''
       }

--- a/app/webFrontend/src/styles.scss
+++ b/app/webFrontend/src/styles.scss
@@ -3,7 +3,6 @@
 // Plus imports for other components in your app.
 
 // Custom global geli stuff
-@import 'global-hacks';
 @import 'breakpoints';
 
 // Include the common styles for Angular Material. We include this here so that you only


### PR DESCRIPTION
## Description:
Removes global css hack for matDialog

## Improvements
- Now using MaterialOptions not a dirty css hack

## Known Issues:
_NONE_

------
_Remember to prefix your PR-Title with `⚠ WIP: ` if you still work on it.
If you have reached a final state, remove the prefix._
