### PR TITLE
Fix double slash in mail api path

### DIFF
--- a/app/webFrontend/src/app/shared/services/data.service.ts
+++ b/app/webFrontend/src/app/shared/services/data.service.ts
@@ -249,7 +249,7 @@ export class CourseService extends DataService {
 
   sendMailToSelectedUsers(data: any): Promise<any> {
     return this.backendService
-        .post(this.apiPath + '/mail', JSON.stringify(data))
+        .post(this.apiPath + 'mail', JSON.stringify(data))
         .toPromise();
   }
 


### PR DESCRIPTION
## Improvements
- Fixes broken frontend mail api path

related to #404 and #19 