### PR TITLE
Fix ts errors and export import sorting

### DIFF
--- a/api/src/controllers/DuplicationController.ts
+++ b/api/src/controllers/DuplicationController.ts
@@ -23,7 +23,7 @@ export class DuplicationController {
     try {
       const courseModel: ICourseModel = await Course.findById(id);
       const exportedCourse: ICourse = await courseModel.exportJSON();
-      return Course.importJSON(exportedCourse, courseAdmin);
+      return Course.schema.statics.importJSON(exportedCourse, courseAdmin);
     } catch (err) {
         const newError = new InternalServerError('Failed to duplicate course');
         newError.stack += '\nCaused by: ' + err.message + '\n' + err.stack;
@@ -37,7 +37,7 @@ export class DuplicationController {
     try {
       const lectureModel: ILectureModel = await Lecture.findById(id);
       const exportedLecture: ILecture = await lectureModel.exportJSON();
-      return Lecture.importJSON(exportedLecture, courseId);
+      return Lecture.schema.statics.importJSON(exportedLecture, courseId);
     } catch (err) {
       const newError = new InternalServerError('Failed to duplicate lecture');
       newError.stack += '\nCaused by: ' + err.message + '\n' + err.stack;
@@ -53,7 +53,7 @@ export class DuplicationController {
       const unitModel: IUnitModel = await Unit.findById(id);
       const exportedUnit: IUnit = await unitModel.exportJSON();
       const unitTypeClass = UnitClassMapper.getMongooseClassForUnit(exportedUnit);
-      return unitTypeClass.importJSON(exportedUnit, courseId, lectureId);
+      return unitTypeClass.schema.statics.importJSON(exportedUnit, courseId, lectureId);
     } catch (err) {
       const newError = new InternalServerError('Failed to duplicate unit');
       newError.stack += '\nCaused by: ' + err.message + '\n' + err.stack;

--- a/api/src/controllers/ImportController.ts
+++ b/api/src/controllers/ImportController.ts
@@ -15,14 +15,14 @@ export class ImportController {
   async importCourse(@UploadedFile('file') file: any,
                      @CurrentUser() user: IUser) {
     const courseDesc = JSON.parse(file.buffer.toString());
-    return Course.importJSON(courseDesc, user);
+    return Course.schema.statics.importJSON(courseDesc, user);
   }
 
   @Post('/lecture/:course')
   async importLecture(@UploadedFile('file') file: any,
                       @Param('course') courseId: string) {
     const lectureDesc = JSON.parse(file.buffer.toString());
-    return Lecture.importJSON(lectureDesc, courseId);
+    return Lecture.schema.statics.importJSON(lectureDesc, courseId);
   }
 
   @Post('/unit/:course/:lecture')
@@ -31,6 +31,6 @@ export class ImportController {
                    @Param('lecture') lectureId: string) {
     const unitDesc = JSON.parse(file.buffer.toString());
     const unitTypeClass = UnitClassMapper.getMongooseClassForUnit(unitDesc);
-    return unitTypeClass.importJSON(unitDesc, courseId, lectureId);
+    return unitTypeClass.schema.statics.importJSON(unitDesc, courseId, lectureId);
   }
 }

--- a/api/src/models/Course.ts
+++ b/api/src/models/Course.ts
@@ -102,15 +102,16 @@ courseSchema.methods.exportJSON = async function () {
   const lectures: Array<mongoose.Types.ObjectId> = obj.lectures;
   obj.lectures = [];
 
-  obj.lectures = await Promise.all(lectures.map((lectureId: mongoose.Types.ObjectId) => {
-    return Lecture.findById(lectureId).then((lecture: ILectureModel) => {
-      if (lecture) {
-        return lecture.exportJSON();
-      } else {
-        winston.log('warn', 'lecture(' + lectureId + ') was referenced by course(' + this._id + ') but does not exist anymore');
-      }
-    });
-  }));
+  for (const lectureId of lectures) {
+    const lecture: ILectureModel = await Lecture.findById(lectureId);
+    if (lecture) {
+      const lectureExport = await lecture.exportJSON();
+      obj.lectures.push(lectureExport);
+    } else {
+      winston.log('warn', 'lecture(' + lectureId + ') was referenced by course(' + this._id + ') but does not exist anymore');
+    }
+  }
+
   return obj;
 };
 
@@ -131,9 +132,9 @@ courseSchema.statics.importJSON = async function (course: ICourse, admin: IUser)
       course.name = course.name + ' (copy)';
     }
     const savedCourse = await new Course(course).save();
-    await Promise.all(lectures.map((lecture: ILecture) => {
-      return Lecture.schema.statics.importJSON(lecture, savedCourse._id);
-    }));
+    for (const lecture of lectures) {
+      await Lecture.schema.statics.importJSON(lecture, savedCourse._id);
+    }
     const newCourse: ICourseModel = await Course.findById(savedCourse._id);
 
     return newCourse.toObject();

--- a/api/src/models/Course.ts
+++ b/api/src/models/Course.ts
@@ -132,7 +132,7 @@ courseSchema.statics.importJSON = async function (course: ICourse, admin: IUser)
     }
     const savedCourse = await new Course(course).save();
     await Promise.all(lectures.map((lecture: ILecture) => {
-      return Lecture.importJSON(lecture, savedCourse._id);
+      return Lecture.schema.statics.importJSON(lecture, savedCourse._id);
     }));
 
     return (await Course.findById(savedCourse._id)).toObject();

--- a/api/src/models/Course.ts
+++ b/api/src/models/Course.ts
@@ -134,8 +134,9 @@ courseSchema.statics.importJSON = async function (course: ICourse, admin: IUser)
     await Promise.all(lectures.map((lecture: ILecture) => {
       return Lecture.schema.statics.importJSON(lecture, savedCourse._id);
     }));
+    const newCourse: ICourseModel = await Course.findById(savedCourse._id);
 
-    return (await Course.findById(savedCourse._id)).toObject();
+    return newCourse.toObject();
   } catch (err) {
     const newError = new InternalServerError('Failed to import course');
     newError.stack += '\nCaused by: ' + err.message + '\n' + err.stack;

--- a/api/src/models/Lecture.ts
+++ b/api/src/models/Lecture.ts
@@ -86,7 +86,7 @@ lectureSchema.statics.importJSON = async function(lecture: ILecture, courseId: s
 
     await Promise.all(units.map((unit: IUnit) => {
       const unitTypeClass = UnitClassMapper.getMongooseClassForUnit(unit);
-      return unitTypeClass.importJSON(unit, courseId, savedLecture._id);
+      return unitTypeClass.schema.statics.importJSON(unit, courseId, savedLecture._id);
     }));
 
     return (await Lecture.findById(savedLecture._id)).toObject();

--- a/api/src/models/Lecture.ts
+++ b/api/src/models/Lecture.ts
@@ -60,15 +60,16 @@ lectureSchema.methods.exportJSON = async function() {
   const units: Array<mongoose.Types.ObjectId>  = obj.units;
   obj.units = [];
 
-  obj.units = await Promise.all(units.map((unitId: mongoose.Types.ObjectId) => {
-    return Unit.findById(unitId).then((unit: IUnitModel) => {
-      if (unit) {
-        return unit.exportJSON();
-      } else {
-        winston.log('warn', 'unit(' + unitId + ') was referenced by lecture(' + this._id + ') but does not exist anymore');
-      }
-    });
-  }));
+  for (const unitId of units) {
+    const unit: IUnitModel = await Unit.findById(unitId);
+    if (unit) {
+      const unitExport = await unit.exportJSON();
+      obj.units.push(unitExport);
+    } else {
+      winston.log('warn', 'unit(' + unitId + ') was referenced by lecture(' + this._id + ') but does not exist anymore');
+    }
+  }
+
   return obj;
 };
 
@@ -84,10 +85,10 @@ lectureSchema.statics.importJSON = async function(lecture: ILecture, courseId: s
     course.lectures.push(savedLecture);
     await course.save();
 
-    await Promise.all(units.map((unit: IUnit) => {
+    for (const unit of units) {
       const unitTypeClass = UnitClassMapper.getMongooseClassForUnit(unit);
-      return unitTypeClass.schema.statics.importJSON(unit, courseId, savedLecture._id);
-    }));
+      await unitTypeClass.schema.statics.importJSON(unit, courseId, savedLecture._id);
+    }
     const newLecture: ILectureModel = await Lecture.findById(savedLecture._id);
 
     return newLecture.toObject();

--- a/api/src/models/Lecture.ts
+++ b/api/src/models/Lecture.ts
@@ -88,8 +88,9 @@ lectureSchema.statics.importJSON = async function(lecture: ILecture, courseId: s
       const unitTypeClass = UnitClassMapper.getMongooseClassForUnit(unit);
       return unitTypeClass.schema.statics.importJSON(unit, courseId, savedLecture._id);
     }));
+    const newLecture: ILectureModel = await Lecture.findById(savedLecture._id);
 
-    return (await Lecture.findById(savedLecture._id)).toObject();
+    return newLecture.toObject();
   } catch (err) {
     const newError = new InternalServerError('Failed to import lecture');
     newError.stack += '\nCaused by: ' + err.message + '\n' + err.stack;

--- a/api/src/models/units/TaskUnit.ts
+++ b/api/src/models/units/TaskUnit.ts
@@ -67,7 +67,7 @@ taskUnitSchema.statics.importJSON = async function(taskUnit: ITaskUnit, courseId
   try {
   const savedTaskUnit = await new TaskUnit(taskUnit).save();
   taskUnit.tasks = await Promise.all(tasks.map((task: ITask) => {
-    return Task.importJSON(task, savedTaskUnit._id);
+    return Task.schema.statics.importJSON(task, savedTaskUnit._id);
   }));
 
   const lecture = await Lecture.findById(lectureId);

--- a/api/src/models/units/TaskUnit.ts
+++ b/api/src/models/units/TaskUnit.ts
@@ -56,7 +56,7 @@ taskUnitSchema.methods.exportJSON = function() {
     obj.tasks = exportedTasks;
     return obj;
   });
-}
+};
 
 taskUnitSchema.statics.importJSON = async function(taskUnit: ITaskUnit, courseId: string, lectureId: string) {
   taskUnit._course = courseId;
@@ -80,7 +80,7 @@ taskUnitSchema.statics.importJSON = async function(taskUnit: ITaskUnit, courseId
     newError.stack += '\nCaused by: ' + err.message + '\n' + err.stack;
     throw newError;
   }
-}
+};
 
 const TaskUnit = Unit.discriminator('task', taskUnitSchema);
 

--- a/api/src/models/units/TaskUnit.ts
+++ b/api/src/models/units/TaskUnit.ts
@@ -30,7 +30,7 @@ taskUnitSchema.pre('remove', function(next: () => void) {
     .catch(next);
 });
 
-taskUnitSchema.methods.exportJSON = function() {
+taskUnitSchema.methods.exportJSON = async function() {
   const obj = this.toObject();
 
   // remove unwanted informations
@@ -47,15 +47,13 @@ taskUnitSchema.methods.exportJSON = function() {
   const tasks: Array<mongoose.Types.ObjectId>  = obj.tasks;
   obj.tasks = [];
 
-  return Promise.all(tasks.map((taskId) => {
-    return Task.findById(taskId).then((task) => {
-      return task.exportJSON();
-    });
-  }))
-  .then((exportedTasks) => {
-    obj.tasks = exportedTasks;
-    return obj;
-  });
+  for (const taskId of tasks) {
+    const task: ITaskModel = await Task.findById(taskId);
+    const taskExport = await task.exportJSON();
+    obj.tasks.push(taskExport);
+  }
+
+  return obj;
 };
 
 taskUnitSchema.statics.importJSON = async function(taskUnit: ITaskUnit, courseId: string, lectureId: string) {
@@ -66,9 +64,11 @@ taskUnitSchema.statics.importJSON = async function(taskUnit: ITaskUnit, courseId
 
   try {
   const savedTaskUnit = await new TaskUnit(taskUnit).save();
-  taskUnit.tasks = await Promise.all(tasks.map((task: ITask) => {
-    return Task.schema.statics.importJSON(task, savedTaskUnit._id);
-  }));
+
+  for (const task of tasks) {
+    const newTask: ITask = await Task.schema.statics.importJSON(task, savedTaskUnit._id);
+    taskUnit.tasks.push(newTask);
+  }
 
   const lecture = await Lecture.findById(lectureId);
   lecture.units.push(<ITaskUnitModel>savedTaskUnit);


### PR DESCRIPTION
## Description:

Fixes the ts errors below as well as export and import sorting:

```
src\controllers\DuplicationController.ts(26,21): error TS2339: Property 'importJSON' does not exist on type 'Model<ICourseModel>'.
src\controllers\DuplicationController.ts(40,22): error TS2339: Property 'importJSON' does not exist on type 'Model<ILectureModel>'.
src\controllers\ImportController.ts(18,19): error TS2339: Property 'importJSON' does not exist on type 'Model<ICourseModel>'.
src\controllers\ImportController.ts(25,20): error TS2339: Property 'importJSON' does not exist on type 'Model<ILectureModel>'.
src\models\Course.ts(135,22): error TS2339: Property 'importJSON' does not exist on type 'Model<ILectureModel>'.
src\models\units\TaskUnit.ts(70,17): error TS2339: Property 'importJSON' does not exist on type 'Model<ITaskModel>'.
```

## Improvements
- no more ts compile errors
- arrays keep their ordering during import/export

related to #42