### PR TITLE
Bugfix/lecture minify with icon

### DIFF
--- a/app/webFrontend/src/app/lecture/lecture.component.html
+++ b/app/webFrontend/src/app/lecture/lecture.component.html
@@ -1,5 +1,5 @@
 <ng-container class="lecture-container" *ngIf="lecture">
-  <app-expandable-div [title]="lecture.name" (notifyParent)="toggleOpen($event)"></app-expandable-div>
+  <app-expandable-div [title]="lecture.name" [headerTag]="headerTags.H2" (notifyParent)="toggleOpen($event)"></app-expandable-div>
   <p>{{lecture.description}}</p>
   <div *ngIf="this.opened">
     <app-unit *ngIf="lecture.units" [units]="lecture.units"></app-unit>

--- a/app/webFrontend/src/app/lecture/lecture.component.ts
+++ b/app/webFrontend/src/app/lecture/lecture.component.ts
@@ -2,6 +2,7 @@ import {Component, OnInit, Input} from '@angular/core';
 import {UserService} from '../shared/services/user.service';
 import {ICourse} from '../../../../../shared/models/ICourse';
 import {ILecture} from '../../../../../shared/models/ILecture';
+import {ExpandableDivHeaderTags} from '../shared/components/expandable-div/expandable-div-header-tags.enum';
 
 @Component({
   selector: 'app-lecture',
@@ -13,6 +14,8 @@ export class LectureComponent implements OnInit {
   @Input() course: ICourse;
   @Input() lecture: ILecture;
   opened: boolean;
+  private headerTags = ExpandableDivHeaderTags;
+
   constructor(public userService: UserService) {
     this.opened = true;
   }

--- a/app/webFrontend/src/app/shared/components/expandable-div/expandable-div-header-tags.enum.ts
+++ b/app/webFrontend/src/app/shared/components/expandable-div/expandable-div-header-tags.enum.ts
@@ -1,0 +1,9 @@
+export enum ExpandableDivHeaderTags {
+  H1 = 'h1',
+  H2 = 'h2',
+  H3 = 'h3',
+  H4 = 'h4',
+  H5 = 'h5',
+  H6 = 'h6',
+  Text = 'text',
+}

--- a/app/webFrontend/src/app/shared/components/expandable-div/expandable-div.component.html
+++ b/app/webFrontend/src/app/shared/components/expandable-div/expandable-div.component.html
@@ -1,8 +1,9 @@
 <div class="clickable" (click)="notify()">
-  <h1>{{title}}
+  <h2>
+    {{title}}
     <button class="toggle" [class.opened] = "opened" mat-icon-button>
       <mat-icon>arrow_drop_down</mat-icon>
     </button>
-  </h1>
+  </h2>
 
 </div>

--- a/app/webFrontend/src/app/shared/components/expandable-div/expandable-div.component.html
+++ b/app/webFrontend/src/app/shared/components/expandable-div/expandable-div.component.html
@@ -1,9 +1,16 @@
-<div class="clickable" (click)="notify()">
-  <h2>
-    {{title}}
-    <button class="toggle" [class.opened] = "opened" mat-icon-button>
-      <mat-icon>arrow_drop_down</mat-icon>
-    </button>
-  </h2>
+<ng-template #innerContent>
+  {{title}}
+  <button class="toggle" [class.opened] = "opened" mat-icon-button>
+    <mat-icon>arrow_drop_down</mat-icon>
+  </button>
+</ng-template>
 
+<div class="clickable" (click)="notify()">
+  <h1 *ngIf="headerTag == 'h1'"><ng-container *ngTemplateOutlet="innerContent"></ng-container></h1>
+  <h2 *ngIf="headerTag == 'h2'"><ng-container *ngTemplateOutlet="innerContent"></ng-container></h2>
+  <h3 *ngIf="headerTag == 'h3'"><ng-container *ngTemplateOutlet="innerContent"></ng-container></h3>
+  <h4 *ngIf="headerTag == 'h4'"><ng-container *ngTemplateOutlet="innerContent"></ng-container></h4>
+  <h5 *ngIf="headerTag == 'h5'"><ng-container *ngTemplateOutlet="innerContent"></ng-container></h5>
+  <h6 *ngIf="headerTag == 'h6'"><ng-container *ngTemplateOutlet="innerContent"></ng-container></h6>
+  <span class="bold" *ngIf="headerTag == 'text'"><ng-container *ngTemplateOutlet="innerContent"></ng-container></span>
 </div>

--- a/app/webFrontend/src/app/shared/components/expandable-div/expandable-div.component.scss
+++ b/app/webFrontend/src/app/shared/components/expandable-div/expandable-div.component.scss
@@ -4,7 +4,6 @@
   display: inline-block;
   vertical-align: middle;
   color: map-get($app-primary,'default');
-  float: right;
   transition: transform 0.3s;
   transform: rotate(-90deg);
   &.opened {
@@ -14,4 +13,8 @@
 
 .clickable {
   cursor: pointer;
+}
+
+.bold {
+  font-weight: bold;
 }

--- a/app/webFrontend/src/app/shared/components/expandable-div/expandable-div.component.ts
+++ b/app/webFrontend/src/app/shared/components/expandable-div/expandable-div.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, ViewEncapsulation, EventEmitter, Output, Input } from '@angular/core';
+import {ExpandableDivHeaderTags} from './expandable-div-header-tags.enum';
 
 @Component({
   selector: 'app-expandable-div',
@@ -11,12 +12,15 @@ export class ExpandableDivComponent implements OnInit {
   notifyParent: EventEmitter<any> = new EventEmitter();
   @Input()
   title: string;
+  @Input()
+  headerTag: string;
   opened: boolean;
 
   constructor() { }
 
   ngOnInit() {
     this.opened = true;
+    this.headerTag = this.headerTag || ExpandableDivHeaderTags.Text;
   }
 
   notify() {


### PR DESCRIPTION
## Description:

## Improvements
- pulls the lecture opened Icon to the heading
- Makes the expandable-div more generic to have h1-h6 and a span heading
- Sets lecture headings to h2 instead of h1

## Known Issues:
_NONE_

------
_Remember to prefix your PR-Title with `⚠ WIP: ` if you still work on it.
If you have reached a final state, remove the prefix._
