### PR TITLE
await actual removal of course before returning

### DIFF
--- a/api/src/controllers/CourseController.ts
+++ b/api/src/controllers/CourseController.ts
@@ -257,7 +257,7 @@ export class CourseController {
     const courseAdmin = await User.findOne({_id: course.courseAdmin});
     if (course.teachers.indexOf(currentUser._id) !== -1 || courseAdmin.equals(currentUser._id.toString())
       || currentUser.role === 'admin' ) {
-      course.remove();
+      await course.remove();
       return {result: true};
     } else {
       throw new ForbiddenError('Forbidden!');


### PR DESCRIPTION
`DELETE /course/:id`
- wait for actual deletion of course before successfully returning

This is espacially needed for the Tests do validate this function

The corresponding Test does not test if the deletion was successfull yet
-> I fixed this in my branch #434