### PR TITLE
disallow admins to revoke their own privileges

### DIFF
--- a/api/src/controllers/UserController.ts
+++ b/api/src/controllers/UserController.ts
@@ -81,11 +81,10 @@ export class UserController {
   updateUser(@Param('id') id: string, @Body() user: any, @CurrentUser() currentUser?: IUser) {
     return User.find({'role': 'admin'})
       .then((adminUsers) => {
-        if (adminUsers.length === 1 &&
-          adminUsers[0].get('id') === id &&
-          adminUsers[0].role === 'admin' &&
-          user.role !== 'admin') {
-          throw new BadRequestError('There are no other users with admin privileges.');
+        if (id === currentUser._id
+            && currentUser.role === 'admin'
+            && user.role !== 'admin') {
+          throw new BadRequestError('You can\'t revoke your own privileges');
         } else {
           return User.find({ $and: [{'email': user.email}, {'_id': { $ne: user._id }}]});
         }

--- a/api/src/controllers/UserController.ts
+++ b/api/src/controllers/UserController.ts
@@ -84,7 +84,7 @@ export class UserController {
         if (id === currentUser._id
             && currentUser.role === 'admin'
             && user.role !== 'admin') {
-          throw new BadRequestError('You can\'t revoke your own privileges');
+          throw new BadRequestError('There are no other users with admin privileges.');
         } else {
           return User.find({ $and: [{'email': user.email}, {'_id': { $ne: user._id }}]});
         }

--- a/app/webFrontend/src/app/admin/user-admin/user-admin.component.ts
+++ b/app/webFrontend/src/app/admin/user-admin/user-admin.component.ts
@@ -53,6 +53,7 @@ export class UserAdminComponent implements OnInit {
       },
       (error) => {
         this.showProgress.toggleLoadingGlobal(false);
+        this.snackBar.open(error.json().message, 'Desmiss', {duration: 3000})
       }
     );
   }

--- a/app/webFrontend/src/app/admin/user-admin/user-admin.component.ts
+++ b/app/webFrontend/src/app/admin/user-admin/user-admin.component.ts
@@ -52,8 +52,8 @@ export class UserAdminComponent implements OnInit {
         this.snackBar.open('Role of user ' + val.email + ' successfully updated to ' + val.role, '', {duration: 3000});
       },
       (error) => {
+        this.snackBar.open(error.error.message, 'Desmiss', {duration: 3000});
         this.showProgress.toggleLoadingGlobal(false);
-        this.snackBar.open(error.json().message, 'Desmiss', {duration: 3000})
       }
     );
   }

--- a/app/webFrontend/src/app/admin/user-admin/user-admin.component.ts
+++ b/app/webFrontend/src/app/admin/user-admin/user-admin.component.ts
@@ -52,7 +52,7 @@ export class UserAdminComponent implements OnInit {
         this.snackBar.open('Role of user ' + val.email + ' successfully updated to ' + val.role, '', {duration: 3000});
       },
       (error) => {
-        this.snackBar.open(error.error.message, 'Desmiss', {duration: 3000});
+        this.snackBar.open(error.error.message, '', {duration: 3000});
         this.showProgress.toggleLoadingGlobal(false);
       }
     );


### PR DESCRIPTION
disallow admins to revoke their own privileges

-> there will always exist at least one admin
-> much more easy to test than the previous one

ErrorMessage will be changed from `There are no other users with admin privileges.` to `You can\'t revoke your own privileges` in #434 