### PR TITLE
Upgrades Nodemailer-markdown version to avoid XSS

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -4581,7 +4581,8 @@
     "marked": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc="
+      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -5025,11 +5026,18 @@
       "integrity": "sha512-1bnszJJXatcHJhLpxQ1XMkLDjCjPKvGKMtRQ73FOsoNln3UQjddEQmz6fAwM3aj0GtQ3dQX9qtMHPelz63GU7A=="
     },
     "nodemailer-markdown": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/nodemailer-markdown/-/nodemailer-markdown-1.0.1.tgz",
-      "integrity": "sha1-s7m0IMPOWov78J4EzZoISdaD3HM=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/nodemailer-markdown/-/nodemailer-markdown-1.0.2.tgz",
+      "integrity": "sha512-wptrT4ijaqn5Qwl5ib6Fpzfg7g4Hu/PXqX027GOziXwJTFiSHvlfQ6/xXivhH6sU8TM/ULtVd/L3Yt/oIQSPWg==",
       "requires": {
-        "marked": "0.3.6"
+        "marked": "0.3.9"
+      },
+      "dependencies": {
+        "marked": {
+          "version": "0.3.9",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.9.tgz",
+          "integrity": "sha512-nW5u0dxpXxHfkHzzrveY45gCbi+R4PaO4WRZYqZNl+vB0hVGeqlFn0aOg1c8AKL63TrNFn9Bm2UP4AdiZ9TPLw=="
+        }
       }
     },
     "nodemon": {

--- a/api/package.json
+++ b/api/package.json
@@ -39,7 +39,7 @@
     "morgan": "^1.9.0",
     "multer": "^1.3.0",
     "nodemailer": "^4.4.1",
-    "nodemailer-markdown": "^1.0.1",
+    "nodemailer-markdown": "^1.0.2",
     "passport": "^0.4.0",
     "passport-jwt": "^3.0.1",
     "passport-local": "^1.0.0",


### PR DESCRIPTION
## Description:
Upgrades Nodemailer-Markdown, to upgrade the `marked`-dependency which has a XSS vulnerability.

## Improvements
- Removes XSS Bug

## Known Issues:
_NONE_

------
_Remember to prefix your PR-Title with `⚠ WIP: ` if you still work on it.
If you have reached a final state, remove the prefix._
