### PR TITLE
throw 401 if no authorization header is set

### DIFF
--- a/api/src/security/RoleAuthorization.ts
+++ b/api/src/security/RoleAuthorization.ts
@@ -10,7 +10,11 @@ export class RoleAuthorization {
     if (!authorizationHeader) {
       throw new UnauthorizedError();
     }
-    const token = authorizationHeader.split(' ')[1];
+    const authorizationSplit = authorizationHeader.split(' ');
+    if (authorizationSplit.length < 2) {
+      throw new UnauthorizedError();
+    }
+    const token = authorizationSplit[1];
     const decoded: any = jwt.verify(token, config.secret);
     const userId = decoded._id;
 

--- a/api/src/security/RoleAuthorization.ts
+++ b/api/src/security/RoleAuthorization.ts
@@ -1,12 +1,16 @@
 import config from '../config/main';
-import {Action} from 'routing-controllers';
+import {Action, UnauthorizedError} from 'routing-controllers';
 import {User} from '../models/User';
 import jwt = require('jsonwebtoken');
 import * as mongoose from 'mongoose';
 
 export class RoleAuthorization {
   static checkAuthorization(action: Action, roles: string[]): Promise<any> {
-    const token = action.request.headers['authorization'].split(' ')[1];
+    const authorizationHeader = action.request.headers['authorization'];
+    if (!authorizationHeader) {
+      throw new UnauthorizedError();
+    }
+    const token = authorizationHeader.split(' ')[1];
     const decoded: any = jwt.verify(token, config.secret);
     const userId = decoded._id;
 


### PR DESCRIPTION
## Description:

Currently the RoleAuthorization throws an Exception on `action.request.headers['authorization'].split(' ')[1]` if no authorization header is set.
This change will throw an HTTP-UnauthorizedErrorinstead.

