### PR TITLE
Bugfix: Fixed wrong route to download course

### DIFF
--- a/app/webFrontend/src/app/shared/services/data.service.ts
+++ b/app/webFrontend/src/app/shared/services/data.service.ts
@@ -383,7 +383,7 @@ export class DownloadFileService extends DataService {
 
   getPackageSize(idl: IDownload) {
     return new Promise((resolve, reject) => {
-      this.backendService.post(this.apiPath + '/size', idl).subscribe((responseItem: any) => {
+      this.backendService.post(this.apiPath + 'size', idl).subscribe((responseItem: any) => {
           resolve(responseItem);
         },
         error => reject(error));


### PR DESCRIPTION
## Description:
Fix the download of a course.

Closes #483 

## Improvements
- Now the download works

## Known Issues:
_NONE_

------
_Remember to prefix your PR-Title with `⚠ WIP: ` if you still work on it.
If you have reached a final state, remove the prefix._
