### PR TITLE
Fixed wrong download path

### DIFF
--- a/app/webFrontend/src/app/course/course-detail/download-course-dialog/downloadCheckBoxes/upload-unit-checkbox.component.ts
+++ b/app/webFrontend/src/app/course/course-detail/download-course-dialog/downloadCheckBoxes/upload-unit-checkbox.component.ts
@@ -33,7 +33,7 @@ export class UploadUnitCheckboxComponent implements OnInit {
   }
 
   downloadFile() {
-    const downloadLink = BackendService.API_URL + '/uploads/' + this.file.name;
+    const downloadLink = BackendService.API_URL + 'uploads/' + this.file.name;
 
     if (window.navigator && window.navigator.msSaveOrOpenBlob) {
       window.navigator.msSaveOrOpenBlob(downloadLink, this.file.alias);


### PR DESCRIPTION
## Description:
This fixes the reported problem in #260  

Closes #495 

## Improvements
- Download a file trough the download course component

## Known Issues:
_NONE_

------
_Remember to prefix your PR-Title with `⚠ WIP: ` if you still work on it.
If you have reached a final state, remove the prefix._
