### PR TITLE
Display error message on failed logins

### DIFF
--- a/api/src/security/passportLoginMiddleware.ts
+++ b/api/src/security/passportLoginMiddleware.ts
@@ -1,3 +1,12 @@
 import {authenticate} from 'passport';
 
-export default authenticate('local', { session: false });
+export default function passportLoginMiddleware(req: any, res: any, next: (err: any) => any) {
+  const authFunction = authenticate('local', { session: false });
+  authFunction(req, res, (err: any) => {
+    if (err) {
+      res.status(401).json(err); // set status and json body, does not get set automatically
+      return next(err); // pass error to further error handling functions
+    }
+    return next(null);
+  });
+}

--- a/app/webFrontend/src/app/auth/login/login.component.ts
+++ b/app/webFrontend/src/app/auth/login/login.component.ts
@@ -54,8 +54,16 @@ export class LoginComponent implements OnInit {
         this.showProgress.toggleLoadingGlobal(false);
         this.loading = false;
 
-        this.translate.get(['auth.loginFailed', 'common.dismiss']).subscribe((t: string) => {
-          this.snackBar.open(t['auth.loginFailed'], t['common.dismiss'], {duration: 2000});
+        this.translate.get([
+          'auth.loginFailed',
+          'common.dismiss',
+          `auth.loginFailedError.${error.error.message}`
+        ]).subscribe((t: string) => {
+          this.snackBar.open(
+            t['auth.loginFailed'] + ': ' + t[`auth.loginFailedError.${error.error.message}`],
+            t['common.dismiss'],
+            {duration: 2000}
+          );
         });
       });
   }

--- a/app/webFrontend/src/assets/i18n/de.json
+++ b/app/webFrontend/src/assets/i18n/de.json
@@ -32,6 +32,11 @@
     "forgotPassword": "Passwort vergessen",
     "loginSuccess": "Login erfolgreich",
     "loginFailed": "Login fehlgeschlagen",
+    "loginFailedError": {
+      "couldNotBeVerified": "Ihre Login-Daten konnten nicht verifiziert werden. Bitte versuchen sie es noch ein mal.",
+      "notActiveYet": "Ihr Account wurde noch nicht aktiviert.",
+      "unknown": "Es ist ein unbekannter Fehler aufgetreten."
+    },
     "confirmPassword": "Passwort bestätigen",
     "registration": {
       "registerAs": "Registrieren als",

--- a/app/webFrontend/src/assets/i18n/en.json
+++ b/app/webFrontend/src/assets/i18n/en.json
@@ -32,6 +32,11 @@
     "forgotPassword": "Forgot password",
     "loginSuccess": "Login successful",
     "loginFailed": "Login failed",
+    "loginFailedError": {
+      "couldNotBeVerified": "Your login details could not be verified. Please try again.",
+      "notActiveYet": "Your account has not been activated yet.",
+      "unknown": "An unknown error occured."
+    },
     "confirmPassword": "Confirm password",
     "registration": {
       "registerAs": "Register as",


### PR DESCRIPTION
## Improvements
- shows the actual error message in the frontend upon a failed login

## Good to know
I currently abuse the Error message for the translation key. In the future we might want to use a custom translatableError for that purpose and pass a fallback with it or do translation in the backend as well.

Closes #80