### PR TITLE
Bugfix/#520 fix showing full error message

### DIFF
--- a/api/src/controllers/UserController.ts
+++ b/api/src/controllers/UserController.ts
@@ -204,7 +204,7 @@ export class UserController {
       .then((isValidPassword) => {
         if (typeof user.password !== 'undefined') {
           if (!(currentUser.role === 'admin' && currentUser._id !== user._id) && !isValidPassword && user.password.length > 0) {
-            throw new BadRequestError('You must specify your current password if you want to set a new password.');
+            throw new BadRequestError('Invalid Current Password!');
           } else {
             if (user.password.length === 0) {
               delete user.password;

--- a/api/test/integration/user.ts
+++ b/api/test/integration/user.ts
@@ -266,7 +266,7 @@ describe('User', () => {
 
       res.status.should.be.equal(400);
       res.body.name.should.be.equal('BadRequestError');
-      res.body.message.should.be.equal('You must specify your current password if you want to set a new password.');
+      res.body.message.should.be.equal('Invalid Current Password!');
     });
 
     it('should update user data', async () => {

--- a/app/webFrontend/src/app/shared/components/change-password-dialog/change-password-dialog.component.ts
+++ b/app/webFrontend/src/app/shared/components/change-password-dialog/change-password-dialog.component.ts
@@ -67,8 +67,11 @@ export class ChangePasswordDialogComponent implements OnInit {
       this.snackBar.open('Password successfully updated.', '', {duration: 3000});
       this.dialogRef.close();
     } catch (error) {
-      console.dir(error);
-      const errormsg = error.error.message;
+      // console.dir(error);
+      let errormsg = error.error.message;
+      if (!errormsg || 0 === errormsg.length) {
+        errormsg = 'Woops! Sth. went wrong. Please provide the correct Data and try again in a few Minutes!';
+      }
       this.snackBar.open(errormsg, 'Dismiss');
     }
   }

--- a/app/webFrontend/src/app/shared/components/change-password-dialog/change-password-dialog.component.ts
+++ b/app/webFrontend/src/app/shared/components/change-password-dialog/change-password-dialog.component.ts
@@ -68,7 +68,7 @@ export class ChangePasswordDialogComponent implements OnInit {
       this.dialogRef.close();
     } catch (error) {
       console.dir(error);
-      const errormsg = error.message;
+      const errormsg = error.error.message;
       this.snackBar.open(errormsg, 'Dismiss');
     }
   }


### PR DESCRIPTION
## Description:
The Full ErrorMessage won't be displayed in the Frontend, but only the thrown Message on a failed attempt.

Closes #520 

## Known Issues:
- might be related to #513 
