### PR TITLE
Bugfix/#543 code kata unit frontend

### DIFF
--- a/app/webFrontend/src/app/unit/code-kata-unit/code-kata-unit.component.html
+++ b/app/webFrontend/src/app/unit/code-kata-unit/code-kata-unit.component.html
@@ -31,6 +31,8 @@
     <button mat-raised-button (click)="validate()">Validate</button>
     <button mat-raised-button color="primary" class="submit-progress" (click)="submitProgress()">Submit</button>
   </div>
-  <div *ngIf="logs!==undefined"><strong>Logs</strong></div>
-  <pre>{{logs}}</pre>
+  <div *ngIf="logs!==undefined" class="logs-title">
+    Logs:
+    <pre>{{logs}}</pre>
+  </div>
 </div>

--- a/app/webFrontend/src/app/unit/code-kata-unit/code-kata-unit.component.scss
+++ b/app/webFrontend/src/app/unit/code-kata-unit/code-kata-unit.component.scss
@@ -2,9 +2,19 @@ ace-editor {
   margin-top: 0.5em;
   margin-bottom: 1em;
   margin-left: 1em;
-  width: 100%;
+  width: calc(100% - 1em);
 }
 
 .user-code-editor {
   min-height: 15em;
+}
+
+.logs-title {
+  margin-top: 0.5em;
+}
+
+pre {
+  margin-top: 0.5em;
+  margin-left: 1em;
+  font-size: 0.8em;
 }

--- a/app/webFrontend/src/app/unit/code-kata-unit/code-kata-unit.component.scss
+++ b/app/webFrontend/src/app/unit/code-kata-unit/code-kata-unit.component.scss
@@ -2,7 +2,7 @@ ace-editor {
   margin-top: 0.5em;
   margin-bottom: 1em;
   margin-left: 1em;
-  width: 90%;
+  width: 100%;
 }
 
 .user-code-editor {

--- a/app/webFrontend/src/app/unit/code-kata-unit/code-kata-unit.component.scss
+++ b/app/webFrontend/src/app/unit/code-kata-unit/code-kata-unit.component.scss
@@ -16,5 +16,5 @@ ace-editor {
 pre {
   margin-top: 0.5em;
   margin-left: 1em;
-  font-size: 0.8em;
+  font-size: 0.9em;
 }

--- a/app/webFrontend/src/app/unit/code-kata-unit/code-kata-unit.component.ts
+++ b/app/webFrontend/src/app/unit/code-kata-unit/code-kata-unit.component.ts
@@ -62,7 +62,9 @@ export class CodeKataComponent implements OnInit {
     });
     this.testEditor.setOptions({
       maxLines: 9999,
-      firstLineNumber: ((this.codeKataUnit.definition.split('\n').length) || 0) + 1,
+      firstLineNumber: (
+        (this.codeKataUnit.definition.split('\n').length
+          + this.codeEditor.text.split('\n').length) || 0) + 1,
     });
   }
 

--- a/app/webFrontend/src/app/unit/code-kata-unit/code-kata-unit.component.ts
+++ b/app/webFrontend/src/app/unit/code-kata-unit/code-kata-unit.component.ts
@@ -62,9 +62,8 @@ export class CodeKataComponent implements OnInit {
     });
     this.testEditor.setOptions({
       maxLines: 9999,
-      firstLineNumber: (
-        (this.codeKataUnit.definition.split('\n').length
-          + this.codeEditor.text.split('\n').length) || 0) + 1,
+      firstLineNumber: ((this.codeKataUnit.definition.split('\n').length || 0) +
+        (this.codeEditor.text.split('\n').length || 0) + 1),
     });
   }
 

--- a/app/webFrontend/src/app/unit/unit-form/code-kata-unit-form/code-kata-unit-form.component.html
+++ b/app/webFrontend/src/app/unit/unit-form/code-kata-unit-form/code-kata-unit-form.component.html
@@ -22,6 +22,8 @@
 
   <button mat-raised-button (click)="validate()">Validate</button>
   <app-button-save-cancel (save)="addUnit()" (cancel) ="onCancel()"></app-button-save-cancel>
-  <div *ngIf="logs!==undefined"><strong>Logs</strong></div>
-  <pre>{{logs}}</pre>
+  <div *ngIf="logs!==undefined" class="logs-title">
+    Logs:
+    <pre>{{logs}}</pre>
+  </div>
 </div>

--- a/app/webFrontend/src/app/unit/unit-form/code-kata-unit-form/code-kata-unit-form.component.scss
+++ b/app/webFrontend/src/app/unit/unit-form/code-kata-unit-form/code-kata-unit-form.component.scss
@@ -2,6 +2,19 @@ ace-editor {
   margin-top: 0.5em;
   margin-bottom: 1em;
   margin-left: 1em;
-  width: 90%;
+  width: calc(100% - 1em);
+}
+
+.user-code-editor {
   min-height: 15em;
+}
+
+.logs-title {
+  margin-top: 0.5em;
+}
+
+pre {
+  margin-top: 0.5em;
+  margin-left: 1em;
+  font-size: 0.9em;
 }


### PR DESCRIPTION
## Description:
 Frontend UI Problems fixed in code kata unit and code kata unit form
- there was too much space on right side
- there was no space between text and button
- Editor line numbers didn't count correctly

Closes #543 

## Improvements
- some small html refactorings

## Known Issues:
#544 (duplicate code) is too big to be done in this PR

------
_Remember to prefix your PR-Title with `⚠ WIP: ` if you still work on it.
If you have reached a final state, remove the prefix._
