### PR TITLE
Bugfix/544 duplicate code in code kata

### DIFF
--- a/app/webFrontend/src/app/unit/unit-form/code-kata-unit-form/code-kata-unit-form.component.html
+++ b/app/webFrontend/src/app/unit/unit-form/code-kata-unit-form/code-kata-unit-form.component.html
@@ -14,7 +14,7 @@
 
   <ace-editor class="user-code-editor"
               #codeEditor
-              [(text)]="model.code"
+              [(text)]="wholeInputCode"
               [mode]="'javascript'"
               [theme]="'github'"
               [readOnly]="false">

--- a/app/webFrontend/src/app/unit/unit-form/code-kata-unit-form/code-kata-unit-form.component.ts
+++ b/app/webFrontend/src/app/unit/unit-form/code-kata-unit-form/code-kata-unit-form.component.ts
@@ -144,7 +144,6 @@ export class CodeKataUnitFormComponent implements OnInit {
     if (!this.validateStructure()) {
       return false;
     }
-
     const codeToTest: string = this.wholeInputCode;
 
     this.logs = undefined;
@@ -187,6 +186,15 @@ export class CodeKataUnitFormComponent implements OnInit {
 
   // this code gets unnessessary with the Implementation of Issue #44 (all validation parts should happen on the server)
   private validateStructure(): boolean {
+    let separatorCount = (this.wholeInputCode.match(new RegExp(this.areaSeperator, 'gmi')) || []).length;
+    if (separatorCount > 2) {
+      this.snackBar.open('There are too many area separators', 'Dismiss');
+      return false;
+    }
+    if (separatorCount < 2) {
+      this.snackBar.open('There must be 2 area separators', 'Dismiss');
+      return false;
+    }
     if (!this.wholeInputCode.match(new RegExp('function(.|\t)*validate\\(\\)(.|\n|\t)*{(.|\n|\t)*}', 'gmi'))) {
       this.snackBar.open('The test section must contain a validate function', 'Dismiss');
       return false;

--- a/app/webFrontend/src/app/unit/unit-form/code-kata-unit-form/code-kata-unit-form.component.ts
+++ b/app/webFrontend/src/app/unit/unit-form/code-kata-unit-form/code-kata-unit-form.component.ts
@@ -53,7 +53,7 @@ export class CodeKataUnitFormComponent implements OnInit {
   };
 
   logs: string;
-  wholeInputCode:string;
+  wholeInputCode: string;
 
   constructor(private codeKataUnitService: CodeKataUnitService,
               private unitService: UnitService,
@@ -85,7 +85,7 @@ export class CodeKataUnitFormComponent implements OnInit {
       this.snackBar.open('Your code does not validate. Check logs for information', '', {duration: 3000});
     }
 
-    let inputCodeArray = this.wholeInputCode.split('\n' + this.areaSeperator + '\n');
+    const inputCodeArray = this.wholeInputCode.split('\n' + this.areaSeperator + '\n');
     this.model = {
       ...this.model,
       definition: inputCodeArray[0],
@@ -186,7 +186,7 @@ export class CodeKataUnitFormComponent implements OnInit {
 
   // this code gets unnessessary with the Implementation of Issue #44 (all validation parts should happen on the server)
   private validateStructure(): boolean {
-    let separatorCount = (this.wholeInputCode.match(new RegExp(this.areaSeperator, 'gmi')) || []).length;
+    const separatorCount = (this.wholeInputCode.match(new RegExp(this.areaSeperator, 'gmi')) || []).length;
     if (separatorCount > 2) {
       this.snackBar.open('There are too many area separators', 'Dismiss');
       return false;

--- a/app/webFrontend/src/app/unit/unit-form/code-kata-unit-form/code-kata-unit-form.component.ts
+++ b/app/webFrontend/src/app/unit/unit-form/code-kata-unit-form/code-kata-unit-form.component.ts
@@ -65,20 +65,16 @@ export class CodeKataUnitFormComponent implements OnInit {
     if (!this.model) {
       this.model = new CodeKataUnit(this.course._id);
       this.model.definition = this.example.definition;
-      this.model.code = this.example.code
+      this.model.code = this.example.code;
       this.model.test = this.example.test;
-    } else {
-      this.model.code = this.model.code
-      this.model.definition = this.model.definition;
-      this.model.test = this.model.test;
     }
 
     this.wholeInputCode =
       this.model.definition
-      + '\n\n' + this.areaSeperator + '\n\n'
+      + '\n' + this.areaSeperator + '\n'
       + this.model.code
-      + '\n\n' + this.areaSeperator + '\n\n'
-      + this.model.test
+      + '\n' + this.areaSeperator + '\n'
+      + this.model.test;
     this.editor.getEditor().setOptions({
       maxLines: 9999,
     });
@@ -89,7 +85,7 @@ export class CodeKataUnitFormComponent implements OnInit {
       this.snackBar.open('Your code does not validate. Check logs for information', '', {duration: 3000});
     }
 
-    let inputCodeArray = this.wholeInputCode.split(this.areaSeperator);
+    let inputCodeArray = this.wholeInputCode.split('\n' + this.areaSeperator + '\n');
     this.model = {
       ...this.model,
       definition: inputCodeArray[0],

--- a/app/webFrontend/src/app/unit/unit-form/code-kata-unit-form/code-kata-unit-form.component.ts
+++ b/app/webFrontend/src/app/unit/unit-form/code-kata-unit-form/code-kata-unit-form.component.ts
@@ -53,6 +53,7 @@ export class CodeKataUnitFormComponent implements OnInit {
   };
 
   logs: string;
+  wholeInputCode:string;
 
   constructor(private codeKataUnitService: CodeKataUnitService,
               private unitService: UnitService,
@@ -63,25 +64,21 @@ export class CodeKataUnitFormComponent implements OnInit {
   ngOnInit() {
     if (!this.model) {
       this.model = new CodeKataUnit(this.course._id);
-      this.model.code =
-        this.example.definition
-        + '\n\n' + this.areaSeperator + ' code-section' + ((this.example.code.startsWith('//')) ? '\n' : '\n\n')
-        + this.example.code
-        + '\n\n' + this.areaSeperator + ' test-section' + ((this.example.test.startsWith('//')) ? '\n' : '\n\n')
-        + this.example.test;
-      this.model.definition = undefined;
-      this.model.test = undefined;
+      this.model.definition = this.example.definition;
+      this.model.code = this.example.code
+      this.model.test = this.example.test;
     } else {
-      this.model.code =
-        this.model.definition
-        + '\n\n' + this.areaSeperator + '\n\n'
-        + this.model.code
-        + '\n\n' + this.areaSeperator + '\n\n'
-        + this.model.test;
-      this.model.definition = undefined;
-      this.model.test = undefined;
+      this.model.code = this.model.code
+      this.model.definition = this.model.definition;
+      this.model.test = this.model.test;
     }
 
+    this.wholeInputCode =
+      this.model.definition
+      + '\n\n' + this.areaSeperator + '\n\n'
+      + this.model.code
+      + '\n\n' + this.areaSeperator + '\n\n'
+      + this.model.test
     this.editor.getEditor().setOptions({
       maxLines: 9999,
     });
@@ -92,8 +89,12 @@ export class CodeKataUnitFormComponent implements OnInit {
       this.snackBar.open('Your code does not validate. Check logs for information', '', {duration: 3000});
     }
 
+    let inputCodeArray = this.wholeInputCode.split(this.areaSeperator);
     this.model = {
       ...this.model,
+      definition: inputCodeArray[0],
+      code: inputCodeArray[1],
+      test: inputCodeArray[2],
       name: this.generalInfo.form.value.name,
       description: this.generalInfo.form.value.description,
       deadline: this.generalInfo.form.value.deadline,
@@ -148,7 +149,7 @@ export class CodeKataUnitFormComponent implements OnInit {
       return false;
     }
 
-    const codeToTest: string = this.model.code;
+    const codeToTest: string = this.wholeInputCode;
 
     this.logs = undefined;
 
@@ -190,15 +191,15 @@ export class CodeKataUnitFormComponent implements OnInit {
 
   // this code gets unnessessary with the Implementation of Issue #44 (all validation parts should happen on the server)
   private validateStructure(): boolean {
-    if (!this.model.code.match(new RegExp('function(.|\t)*validate\\(\\)(.|\n|\t)*{(.|\n|\t)*}', 'gmi'))) {
+    if (!this.wholeInputCode.match(new RegExp('function(.|\t)*validate\\(\\)(.|\n|\t)*{(.|\n|\t)*}', 'gmi'))) {
       this.snackBar.open('The test section must contain a validate function', 'Dismiss');
       return false;
     }
-    if (!this.model.code.match(new RegExp('function(.|\t)*validate\\(\\)(.|\n|\t)*{(.|\n|\t)*return(.|\n|\t)*}', 'gmi'))) {
+    if (!this.wholeInputCode.match(new RegExp('function(.|\t)*validate\\(\\)(.|\n|\t)*{(.|\n|\t)*return(.|\n|\t)*}', 'gmi'))) {
       this.snackBar.open('The validate function must return something', 'Dismiss');
       return false;
     }
-    if (!this.model.code.match(new RegExp('validate\\(\\);', 'gmi'))) {
+    if (!this.wholeInputCode.match(new RegExp('validate\\(\\);', 'gmi'))) {
       this.snackBar.open('The test section must call the validate function', 'Dismiss');
       return false;
     }


### PR DESCRIPTION
## Description:
Fixes Duplicate code in code kata on saving 
Reason for this was the inconsistent use of the ICodeKataUnit.code property
in some cases ICodeKataUnit.code was used only for the middle Part of the code Kata (example Solution)
in other cases ICodeKataUnit.code was used for the whole code including definition, solution and test section
filling in the whole code into the middle Section results in duplicated code. this is fixed now.

Closes #544

## Improvements
- 

## Known Issues:
refactoring needed: unify or unite several validation functions in code-kata-unit and code-kata-unit-form  and backend