### PR TITLE
Bugfix/#594 CourseController security flaws

### DIFF
--- a/api/fixtures/courses/Access-key-test.json
+++ b/api/fixtures/courses/Access-key-test.json
@@ -1,0 +1,23 @@
+{
+  "name": "Access key test",
+  "description": "This course is used to test the access key course enroll type.",
+  "active": true,
+  "whitelist": [],
+  "enrollType": "accesskey",
+  "accessKey": "accessKey1234",
+  "hasAccessKey": true,
+  "lectures": [
+    {
+      "name": "Documentation",
+      "description": "Documents the course fixture.",
+      "units": [
+        {
+          "name": "What is course fixture for?",
+          "description": "",
+          "markdown": "To test the 'accesskey' enrollType.",
+          "__t": "free-text"
+        }
+      ]
+    }
+  ]
+}

--- a/api/src/controllers/CourseController.ts
+++ b/api/src/controllers/CourseController.ts
@@ -231,7 +231,7 @@ export class CourseController {
 
     // This is currently a redundant check, because userReadConditions above already restricts access!
     // (I.e. just in case future changes break something.)
-    if (!course.checkPrivileges(currentUser).userCanView) {
+    if (!course.checkPrivileges(currentUser).userCanViewCourse) {
       throw new ForbiddenError();
     }
 

--- a/api/src/controllers/CourseController.ts
+++ b/api/src/controllers/CourseController.ts
@@ -32,7 +32,6 @@ import * as mongoose from 'mongoose';
 import {Schema} from 'mongoose';
 import ObjectId = mongoose.Types.ObjectId;
 import {IWhitelistUser} from '../../../shared/models/IWhitelistUser';
-import Pick from '../utilities/Pick';
 
 const uploadOptions = {
   storage: multer.diskStorage({
@@ -489,7 +488,7 @@ export class CourseController {
     if (index >= 0) {
       course.students.splice(index, 1);
       await NotificationSettings.findOne({'user': currentUser, 'course': course}).remove();
-      const savedCourse = await course.save();
+      await course.save();
       return {result: true};
     } else {
       // This equals an implicit !course.checkPrivileges(currentUser).userIsCourseStudent check.

--- a/api/src/controllers/CourseController.ts
+++ b/api/src/controllers/CourseController.ts
@@ -653,22 +653,19 @@ export class CourseController {
    *     }
    *
    * @apiError NotFoundError
-   * @apiError ForbiddenError Forbidden!
+   * @apiError ForbiddenError
    */
   @Authorized(['teacher', 'admin'])
   @Delete('/:id')
   async deleteCourse(@Param('id') id: string, @CurrentUser() currentUser: IUser) {
-    const course = await Course.findOne({_id: id});
+    const course = await Course.findById(id);
     if (!course) {
       throw new NotFoundError();
     }
-    const courseAdmin = await User.findOne({_id: course.courseAdmin});
-    if (course.teachers.indexOf(currentUser._id) !== -1 || courseAdmin.equals(currentUser._id.toString())
-      || currentUser.role === 'admin') {
-      await course.remove();
-      return {result: true};
-    } else {
-      throw new ForbiddenError('Forbidden!');
+    if (!course.checkPrivileges(currentUser).userCanEditCourse) {
+      throw new ForbiddenError();
     }
+    await course.remove();
+    return {result: true};
   }
 }

--- a/api/src/controllers/CourseController.ts
+++ b/api/src/controllers/CourseController.ts
@@ -473,54 +473,30 @@ export class CourseController {
    * @apiSuccess {Course} course Left course.
    *
    * @apiSuccessExample {json} Success-Response:
-   *     {
-   *         "_id": "5a037e6b60f72236d8e7c83d",
-   *         "updatedAt": "2017-11-08T22:00:11.869Z",
-   *         "createdAt": "2017-11-08T22:00:11.263Z",
-   *         "name": "Introduction to web development",
-   *         "description": "Whether you're just getting started with Web development or are just expanding your horizons...",
-   *         "courseAdmin": {
-   *             "_id": "5a037e6a60f72236d8e7c815",
-   *             "updatedAt": "2017-11-08T22:00:10.898Z",
-   *             "createdAt": "2017-11-08T22:00:10.898Z",
-   *             "email": "teacher2@test.local",
-   *             "isActive": true,
-   *             "role": "teacher",
-   *             "profile": {
-   *                 "firstName": "Ober",
-   *                 "lastName": "Lehrer"
-   *             },
-   *             "id": "5a037e6a60f72236d8e7c815"
-   *         },
-   *         "active": true,
-   *         "__v": 1,
-   *         "whitelist": [],
-   *         "enrollType": "free",
-   *         "lectures": [],
-   *         "students": [],
-   *         "teachers": [],
-   *         "id": "5a037e6b60f72236d8e7c83d",
-   *         "hasAccessKey": false
-   *     }
+   *      {result: true}
    *
    * @apiError NotFoundError
+   * @apiError ForbiddenError
    */
   @Authorized(['student'])
   @Post('/:id/leave')
   async leaveStudent(@Param('id') id: string, @Body() data: any, @CurrentUser() currentUser: IUser) {
     const course = await Course.findById(id);
-        if (!course) {
-          throw new NotFoundError();
-        }
-        const index: number = course.students.indexOf(currentUser._id);
-        if (index >= 0) {
-          course.students.splice(index, 1);
-          await NotificationSettings.findOne({'user': currentUser, 'course': course}).remove();
-          const savedCourse = await course.save();
-          return savedCourse.toObject();
-        }
-        return course.toObject();
+    if (!course) {
+      throw new NotFoundError();
+    }
+    const index: number = course.students.indexOf(currentUser._id);
+    if (index >= 0) {
+      course.students.splice(index, 1);
+      await NotificationSettings.findOne({'user': currentUser, 'course': course}).remove();
+      const savedCourse = await course.save();
+      return {result: true};
+    } else {
+      // This equals an implicit !course.checkPrivileges(currentUser).userIsCourseStudent check.
+      throw new ForbiddenError();
+    }
   }
+
 
   /**
    * @api {post} /api/courses/:id/whitelist Whitelist students for course

--- a/api/src/controllers/DuplicationController.ts
+++ b/api/src/controllers/DuplicationController.ts
@@ -55,7 +55,8 @@ export class DuplicationController {
     const courseAdmin = data.courseAdmin;
     try {
       const courseModel: ICourseModel = await Course.findById(id);
-      const exportedCourse: ICourse = await courseModel.exportJSON();
+      const exportedCourse: ICourse = await courseModel.exportJSON(false);
+      delete exportedCourse.students;
       return Course.schema.statics.importJSON(exportedCourse, courseAdmin);
     } catch (err) {
         const newError = new InternalServerError('Failed to duplicate course');

--- a/api/src/models/Course.ts
+++ b/api/src/models/Course.ts
@@ -9,7 +9,7 @@ import * as winston from 'winston';
 import {ObjectID} from 'bson';
 
 interface ICourseModel extends ICourse, mongoose.Document {
-  exportJSON: () => Promise<ICourse>;
+  exportJSON: (sanitize?: boolean) => Promise<ICourse>;
 }
 
 const courseSchema = new mongoose.Schema({
@@ -94,23 +94,27 @@ courseSchema.pre('remove', function (next: () => void) {
     .catch(next);
 });
 
-courseSchema.methods.exportJSON = async function () {
+courseSchema.methods.exportJSON = async function (sanitize: boolean = true) {
   const obj = this.toObject();
 
   // remove unwanted informations
-  // mongo properties
-  delete obj._id;
-  delete obj.createdAt;
-  delete obj.__v;
-  delete obj.updatedAt;
+  {
+    // mongo properties
+    delete obj._id;
+    delete obj.createdAt;
+    delete obj.__v;
+    delete obj.updatedAt;
 
-  // custom properties
-  delete obj.accessKey;
-  delete obj.active;
-  delete obj.whitelist;
-  delete obj.students;
-  delete obj.courseAdmin;
-  delete obj.teachers;
+    // custom properties
+    if (sanitize) {
+      delete obj.accessKey;
+      delete obj.active;
+      delete obj.whitelist;
+      delete obj.students;
+      delete obj.courseAdmin;
+      delete obj.teachers;
+    }
+  }
 
   // "populate" lectures
   const lectures: Array<mongoose.Types.ObjectId> = obj.lectures;

--- a/api/src/models/Course.ts
+++ b/api/src/models/Course.ts
@@ -1,16 +1,22 @@
 import {ICourse} from '../../../shared/models/ICourse';
 import * as mongoose from 'mongoose';
-import {User} from './User';
+import {User, IUserModel} from './User';
 import {ILectureModel, Lecture} from './Lecture';
 import {ILecture} from '../../../shared/models/ILecture';
 import {InternalServerError} from 'routing-controllers';
 import {IUser} from '../../../shared/models/IUser';
 import * as winston from 'winston';
 import {ObjectID} from 'bson';
+import {IProperties} from '../../../shared/models/IProperties';
+import Pick from '../utilities/Pick';
 
 interface ICourseModel extends ICourse, mongoose.Document {
   exportJSON: (sanitize?: boolean) => Promise<ICourse>;
 }
+interface ICourseMongoose extends mongoose.Model<ICourseModel> {
+  getSanitized: (user: IUser, courses: ICourseModel[], targets: ICourseObt) => Promise<IProperties[]>;
+}
+let Course: ICourseMongoose;
 
 const courseSchema = new mongoose.Schema({
     name: {
@@ -172,6 +178,149 @@ courseSchema.statics.importJSON = async function (course: ICourse, admin: IUser,
   }
 };
 
-const Course = mongoose.model<ICourseModel>('Course', courseSchema);
+
+function arrayUnion(...arrays: any[]) {
+  return [...new Set([].concat(...arrays))];
+}
+
+function canUserRoleEditCourse(user: IUser) {
+  const roleIsTeacher: boolean = user.role === 'teacher';
+  const roleIsAdmin: boolean = user.role === 'admin';
+  return roleIsTeacher || roleIsAdmin;
+};
+
+function keysToPath(keys: string[]) {
+  return keys.map(path => ({path}));
+}
+
+function extractId(value: any, fallback?: any) {
+  if (value instanceof Object) {
+    if (value._bsontype === 'ObjectID') {
+      return {_id: value.toString()};
+    } else if ('id' in value) {
+      return {_id: value.id}
+    }
+  }
+  return fallback;
+}
+
+function extractIds(values: any[], fallback?: any) {
+  const results: any[] = [];
+  for (const value of values) {
+    const result = extractId(value, fallback);
+    if (result !== undefined) {
+      results.push(result);
+    }
+  }
+  return results;
+}
+
+// ICourse(Model)-Obtain option interfaces:
+type ICourseObtMode = string[];
+interface ICourseObtType {
+  empty?: ICourseObtMode;
+  selfid?: ICourseObtMode;
+  onlyid?: ICourseObtMode;
+  copy?: ICourseObtMode;
+  populate?: ICourseObtMode;
+}
+interface ICourseObt {
+  safe?: ICourseObtType;
+  editor?: ICourseObtType;
+  all?: ICourseObtType;
+}
+// Normalized:
+type ICourseNormObtMode = ICourseObtMode;
+interface ICourseNormObtType {
+  empty: ICourseNormObtMode;
+  selfid: ICourseNormObtMode;
+  onlyid: ICourseNormObtMode;
+  copy: ICourseNormObtMode;
+  populate: ICourseNormObtMode;
+  populatePaths: IProperties;
+  pickKeys: string[];
+}
+interface ICourseNormObt {
+  safe: ICourseNormObtType;
+  editor: ICourseNormObtType;
+}
+
+function normalizeCourseObtMode(modeObt?: ICourseObtMode): ICourseNormObtMode {
+  if (modeObt !== undefined) {
+    return modeObt.slice();
+  } else {
+    return [];
+  }
+}
+
+function normalizeCourseObt(obt: ICourseObt): ICourseNormObt {
+  const regularTypes = ['safe', 'editor']; // i.e. non-'all'
+  const modes = ['empty', 'selfid', 'onlyid', 'copy', 'populate'];
+  const result: IProperties = {};
+
+  for (const type of regularTypes) {
+    const typeResult = result[type] = <IProperties>{};
+    const typeObt = (<IProperties>obt)[type] || {};
+    for (const mode of modes) {
+      typeResult[mode] = normalizeCourseObtMode(typeObt[mode]);
+    }
+  }
+
+  const allTypeObt = obt.all || {};
+  for (const mode of modes) {
+    const normMode = normalizeCourseObtMode((<IProperties>allTypeObt)[mode]);
+    for (const type of regularTypes) {
+      result[type][mode].push(...normMode);
+    }
+  }
+
+  for (const type of regularTypes) {
+    const typeResult = <ICourseNormObtType>result[type];
+    typeResult.pickKeys = arrayUnion(typeResult.copy, typeResult.populate, typeResult.selfid);
+    typeResult.populatePaths = keysToPath(typeResult.populate);
+  }
+
+  return <ICourseNormObt>result;
+}
+
+courseSchema.statics.getSanitized = async function(user: IUser, courses: ICourseModel[], targets: ICourseObt) {
+  const options = normalizeCourseObt(targets);
+  const roleCanEditCourse: boolean = canUserRoleEditCourse(user);
+
+  return await Promise.all(courses.map(async (course) => {
+    const courseAdminId = course.courseAdmin.toString();
+
+    const userIsCourseAdmin: boolean = user._id === courseAdminId;
+    const userIsCourseTeacher: boolean = course.teachers.some((teacher: IUserModel) => user._id === teacher.toString());
+    const userCanEditCourse: boolean = roleCanEditCourse && (userIsCourseAdmin || userIsCourseTeacher);
+
+    const typeOptions: IProperties = userCanEditCourse ? options.editor : options.safe;
+
+    await Course.populate(course, typeOptions.populatePaths);
+
+    const courseObject: IProperties = course.toObject();
+    const sanitizedCourseObject = Pick.only(typeOptions.pickKeys, courseObject);
+    for (const key of typeOptions.onlyid) {
+      const value = (<IProperties>course)[key];
+      sanitizedCourseObject[key] = Array.isArray(value) ? extractIds(value) : extractId(value);
+    }
+    for (const key of typeOptions.selfid) {
+      const value = (<IProperties>course)[key];
+      if (Array.isArray(value)) {
+        sanitizedCourseObject[key] = extractIds(value).filter(x => user._id === x._id);
+      } else {
+        const extracted = extractId(value);
+        if (user._id === extracted._id) {
+          sanitizedCourseObject[key] = extracted;
+        }
+      }
+    }
+    Pick.asEmpty(typeOptions.empty, courseObject, sanitizedCourseObject);
+
+    return sanitizedCourseObject;
+  }));
+};
+
+Course = mongoose.model<ICourseModel, ICourseMongoose>('Course', courseSchema);
 
 export {Course, ICourseModel};

--- a/api/src/models/Course.ts
+++ b/api/src/models/Course.ts
@@ -219,11 +219,11 @@ courseSchema.methods.checkPrivileges = function (user: IUser) {
 
   const userCanEditCourse: boolean = roleCanEditCourse && (userIsCourseAdmin || userIsCourseTeacher);
   const userIsParticipant: boolean = userIsCourseStudent || userCanEditCourse;
-  const userCanView: boolean = (this.active && userIsCourseStudent) || userCanEditCourse || userIsAdmin;
+  const userCanViewCourse: boolean = (this.active && userIsCourseStudent) || userCanEditCourse || userIsAdmin;
 
   return {roleCanEditCourse, userIsAdmin, courseAdmin,
       userIsCourseAdmin, userIsCourseTeacher, userIsCourseStudent,
-      userCanEditCourse, userIsParticipant, userCanView};
+      userCanEditCourse, userIsParticipant, userCanViewCourse};
 }
 
 

--- a/api/src/utilities/Pick.ts
+++ b/api/src/utilities/Pick.ts
@@ -1,0 +1,22 @@
+import {IProperties} from '../../../shared/models/IProperties';
+
+function only(keys: Array<string>, from: IProperties, to: IProperties = {}) {
+  for (const key of keys) {
+    to[key] = from[key];
+  }
+  return to;
+}
+
+function asEmpty(keys: Array<string>, from: IProperties, to: IProperties = {}) {
+  for (const key of keys) {
+    const value = from[key];
+    if (Array.isArray(value)) {
+      to[key] = [];
+    } else if (value instanceof Object) {
+      to[key] = {};
+    }
+  }
+  return to;
+}
+
+export default {only, asEmpty};

--- a/api/test/integration/course.ts
+++ b/api/test/integration/course.ts
@@ -65,6 +65,25 @@ describe('Course', () => {
         .catch(err => err.response);
         res.status.should.be.equal(401);
     });
+
+
+    it('should have a course fixture with "accesskey" enrollType', async () => {
+      const course = await Course.findOne({enrollType: 'accesskey'});
+      should.exist(course);
+    });
+
+    it('should not leak access keys to students', async () => {
+      const student = await FixtureUtils.getRandomStudent();
+
+      const res = await chai.request(app)
+        .get(BASE_URL)
+        .set('Authorization', `JWT ${JwtUtils.generateToken(student)}`);
+      res.status.should.be.equal(200);
+
+      res.body.forEach((course: any) => {
+        should.equal(course.accessKey, undefined);
+      });
+    });
   });
 
   describe(`POST ${BASE_URL}`, () => {

--- a/api/test/integration/course.ts
+++ b/api/test/integration/course.ts
@@ -165,10 +165,19 @@ describe('Course', () => {
       const savedCourse = await testData.save();
       testDataUpdate._id = savedCourse._id;
 
-      const res = await chai.request(app)
+      let res = await chai.request(app)
         .put(`${BASE_URL}/${testDataUpdate._id}`)
         .set('Authorization', `JWT ${JwtUtils.generateToken(teacher)}`)
         .send(testDataUpdate);
+
+      res.should.have.status(200);
+      res.body.success.should.be.eq(true);
+      res.body.name.should.be.eq(testDataUpdate.name);
+      res.body._id.should.be.eq(testDataUpdate.id);
+
+      res = await chai.request(app)
+        .get(`${BASE_URL}/${res.body._id}`)
+        .set('Authorization', `JWT ${JwtUtils.generateToken(teacher)}`);
 
       res.should.have.status(200);
       res.body.name.should.be.eq(testDataUpdate.name);

--- a/api/test/unit/utilities.ts
+++ b/api/test/unit/utilities.ts
@@ -1,0 +1,23 @@
+import {expect} from 'chai';
+import {IProperties} from '../../../shared/models/IProperties';
+import Pick from '../../src/utilities/Pick';
+
+describe('Testing utilities', () => {
+  describe('Pick', () => {
+    let input: IProperties;
+
+    beforeEach(function() {
+      input = {a: 0, b: 'b', c: [1, 2, 3], d: {e: 'f'}, e: {d: 'c'}};
+    });
+
+    it('should pick only certain attributes', () => {
+      const result: IProperties = Pick.only(['a', 'c'], input);
+      expect(result).to.eql({a: 0, c: [1, 2, 3]});
+    });
+
+    it('should pick certain attributes as empty containers', () => {
+      const result: IProperties = Pick.asEmpty(['a', 'c', 'd'], input);
+      expect(result).to.eql({c: [], d: {}});
+    });
+  });
+});

--- a/app/webFrontend/src/app/course/course-container/course-container.component.ts
+++ b/app/webFrontend/src/app/course/course-container/course-container.component.ts
@@ -69,12 +69,10 @@ export class CourseContainerComponent implements OnInit {
     });
   }
 
-  leaveCallback({courseId}) {
-    this.courseService.leaveStudent(courseId).then((res) => {
+  leaveCallback(result) {
+    if (result) {
       // reload courses to update enrollment status
       this.onLeave.emit();
-    }).catch((err) => {
-      this.snackBar.open(`${err.statusText}: ${JSON.parse(err._body).message}`, '', {duration: 5000});
-    });
+    }
   }
 }

--- a/app/webFrontend/src/app/course/course-edit/general-tab/general-tab.component.ts
+++ b/app/webFrontend/src/app/course/course-edit/general-tab/general-tab.component.ts
@@ -96,8 +96,8 @@ export class GeneralTabComponent implements OnInit {
     };
     this.uploader.onCompleteItem = (item: any, response: any, status: any) => {
       if (status === 200) {
-        const course = JSON.parse(response);
-        this.snackBar.open('Item is uploaded there where ' + course.whitelist.length + ' users parsed!', '', {duration: 10000});
+        const result = JSON.parse(response);
+        this.snackBar.open('Upload complete, there now are ' + result.newlength + ' whitelisted users!', '', {duration: 10000});
         setTimeout(() => {
           this.uploader.clearQueue();
         }, 3000);

--- a/app/webFrontend/src/app/shared/services/data.service.ts
+++ b/app/webFrontend/src/app/shared/services/data.service.ts
@@ -231,10 +231,10 @@ export class CourseService extends DataService {
       .toPromise();
   }
 
-  leaveStudent(courseId: string): Promise<ICourse> {
-    return this.backendService
+  async leaveStudent(courseId: string): Promise<boolean> {
+    return (await this.backendService
       .post(this.apiPath + courseId + '/leave', {})
-      .toPromise();
+      .toPromise()).result;
   }
 }
 

--- a/shared/models/IProperties.ts
+++ b/shared/models/IProperties.ts
@@ -1,0 +1,3 @@
+export interface IProperties {
+  [property: string]: any;
+}


### PR DESCRIPTION
## Description:

Fixes various `CourseController.ts` security issues, especially course information (e.g. `accessKey`) leaks.

Closes #594 

## Improvements

- Adds `IProperties` interface
- Adds `Pick` utility
- Sanitizes `/api/courses/` getCourses
- Adds new course fixture with `accesskey` `enrollType`
- Adds access key student leak test
- Fixes dormant course (access key) duplication issue
- Adds generalized `getSanitized` `Course.ts` static function
- Adds generalized `checkPrivileges` `Course.ts` method
- Reinforces `/api/courses/:id` getCourse security
- Refactors `/api/courses/:id` getCourse
- Refactors `/api/courses/` addCourse
- Fixes app (i.e. front-end) course `leaveCallback` request duplicate
- Fixes `/api/courses/:id/whitelist` whitelistStudents security issues
- Refactors `/api/courses/:id/whitelist` whitelistStudents
- Fixes `/api/courses/:id` updateCourse info leak (non-critical)

## Known Issues:

- The  `/api/courses/` getCourses solution via `getSanitized` seems to be over-engineered (i.e. should be simplified in the future).