### PR TITLE
Fixed restart of fileupload

### DIFF
--- a/api/src/config/errorCodes.ts
+++ b/api/src/config/errorCodes.ts
@@ -51,10 +51,6 @@ export const errorCodes = {
         code: 'wrongTypeCSV',
         text: 'Wrong type allowed are just csv files.'
       }
-    },
-    cancel: {
-      code: 'UploadCancel',
-      text: 'File upload was cancelled.'
     }
   },
   save: {

--- a/api/src/config/errorCodes.ts
+++ b/api/src/config/errorCodes.ts
@@ -51,6 +51,10 @@ export const errorCodes = {
         code: 'wrongTypeCSV',
         text: 'Wrong type allowed are just csv files.'
       }
+    },
+    cancel: {
+      code: 'UploadCancel',
+      text: 'File upload was cancelled.'
     }
   },
   save: {

--- a/app/webFrontend/src/app/shared/components/upload-form/upload-form.component.ts
+++ b/app/webFrontend/src/app/shared/components/upload-form/upload-form.component.ts
@@ -1,6 +1,7 @@
 import {Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges} from '@angular/core';
 import {FileUploader, FileUploaderOptions} from 'ng2-file-upload';
 import {MatSnackBar} from '@angular/material';
+import {errorCodes} from '../../../../../../../api/src/config/errorCodes';
 
 @Component({
   selector: 'app-upload-form',
@@ -60,6 +61,7 @@ export class UploadFormComponent implements OnInit, OnChanges {
 
     this.fileUploader.onCancelItem = () => {
       this.fileUploader.isUploading = false;
+      throw(errorCodes.upload.cancel);
     };
 
     this.fileUploader.onBuildItemForm = (fileItem: any, form: any) => {

--- a/app/webFrontend/src/app/shared/components/upload-form/upload-form.component.ts
+++ b/app/webFrontend/src/app/shared/components/upload-form/upload-form.component.ts
@@ -58,6 +58,10 @@ export class UploadFormComponent implements OnInit, OnChanges {
 
     this.fileUploader = new FileUploader(uploadOptions);
 
+    this.fileUploader.onCancelItem = () => {
+      this.fileUploader.isUploading = false;
+    };
+
     this.fileUploader.onBuildItemForm = (fileItem: any, form: any) => {
       form.append('data', JSON.stringify(this.additionalData))
     };
@@ -103,6 +107,7 @@ export class UploadFormComponent implements OnInit, OnChanges {
       item.isError = false;
       item.isUploaded = false;
       this.snackBar.open(`${item._file.name} failed to upload`, 'Dismiss');
+      this.fileUploader.isUploading = false;
     };
   }
 


### PR DESCRIPTION
Restart of file upload after cancellation or error is now possible

## Description:
added reset of fileUploader status variable "isUploading", so restart of file upload is possible

Closes #380 

## Improvements
- 

## Known Issues:
_NONE_

------
_Remember to prefix your PR-Title with `⚠ WIP: ` if you still work on it.
If you have reached a final state, remove the prefix._
