### PR TITLE
⚠ WIP: Download selection missleading fix

### DIFF
--- a/app/webFrontend/src/app/course/course-detail/download-course-dialog/download-course-dialog.component.ts
+++ b/app/webFrontend/src/app/course/course-detail/download-course-dialog/download-course-dialog.component.ts
@@ -42,10 +42,10 @@ export class DownloadCourseDialogComponent implements OnInit {
   onChange() {
     if (this.chkbox) {
       this.childLectures.forEach(lecture => {
-        if (lecture.chkbox === false) {
+
           lecture.chkbox = true;
           lecture.onChange();
-        }
+
       });
     } else {
       this.childLectures.forEach(lecture => lecture.chkbox = false);
@@ -54,15 +54,20 @@ export class DownloadCourseDialogComponent implements OnInit {
   }
 
   onChildEvent() {
-    let childChecked = false;
+    const childChecked: boolean[] = new Array();
+
     this.childLectures.forEach(lec => {
-      if (lec.chkbox === true) {
-        childChecked = true;
-        this.chkbox = true;
+      if (lec.chkbox === true && !lec.childUnits.find(unit => unit.chkbox === false)) {
+        childChecked.push(true);
+      } else {
+        childChecked.push(false);
       }
     });
-    if (!childChecked) {
+
+    if (childChecked.find(bol => bol === false) !== undefined) {
       this.chkbox = false;
+    } else {
+      this.chkbox = true;
     }
   }
 


### PR DESCRIPTION
## Description:
download course dialog checkbox "Select All" logic checks now if all …child checkboxes are checked, so that it only is selected if all childs are selected

Closes #610

## Improvements
- Select all Checkbox now checks if everything below is checked and so only gets checked if everything is selected

## Known Issues:
_NONE_

------
_Remember to prefix your PR-Title with `⚠ WIP: ` if you still work on it.
If you have reached a final state, remove the prefix._
