### PR TITLE
Reenable Download Button if nothing selected

### DIFF
--- a/app/webFrontend/src/app/course/course-detail/download-course-dialog/download-course-dialog.component.ts
+++ b/app/webFrontend/src/app/course/course-detail/download-course-dialog/download-course-dialog.component.ts
@@ -87,6 +87,7 @@ export class DownloadCourseDialogComponent implements OnInit {
     const obj = await this.buildObject();
     if (obj.lectures.length === 0) {
       this.snackBar.open('No units selected!', 'Dismiss', {duration: 3000});
+      this.disableDownloadButton = false;
       return;
     }
     const downloadObj = <IDownload> obj;


### PR DESCRIPTION
## Description:
Reenable Download Button if nothing selected

Closes #260 

## Improvements
- Reenable Download Button if nothing selected

## Known Issues:
_NONE_

------
_Remember to prefix your PR-Title with `⚠ WIP: ` if you still work on it.
If you have reached a final state, remove the prefix._
