### PR TITLE
Bugfix/#622 checkboxes uncheck after refresh issue

### DIFF
--- a/app/webFrontend/src/app/user/user-settings/user-settings.component.ts
+++ b/app/webFrontend/src/app/user/user-settings/user-settings.component.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../../../../shared/models/INotificationSettings';
 import {NotificationSettings} from '../../models/NotificationSettings';
 import {isNullOrUndefined} from 'util';
-import {AfterContentInit} from "@angular/core/src/metadata/lifecycle_hooks";
+import {AfterContentInit} from '@angular/core/src/metadata/lifecycle_hooks';
 
 @Component({
   selector: 'app-user-settings',
@@ -38,7 +38,7 @@ export class UserSettingsComponent implements OnInit, AfterContentInit {
       this.setSelection();
     });
   }
-    ngAfterContentInit(){
+  ngAfterContentInit() {
     this.getNotificationSettings().then(() => {
       this.setSelection();
     });

--- a/app/webFrontend/src/app/user/user-settings/user-settings.component.ts
+++ b/app/webFrontend/src/app/user/user-settings/user-settings.component.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../../../../shared/models/INotificationSettings';
 import {NotificationSettings} from '../../models/NotificationSettings';
 import {isNullOrUndefined} from 'util';
+import {AfterContentInit} from "@angular/core/src/metadata/lifecycle_hooks";
 
 @Component({
   selector: 'app-user-settings',

--- a/app/webFrontend/src/app/user/user-settings/user-settings.component.ts
+++ b/app/webFrontend/src/app/user/user-settings/user-settings.component.ts
@@ -16,7 +16,7 @@ import {isNullOrUndefined} from 'util';
   templateUrl: './user-settings.component.html',
   styleUrls: ['./user-settings.component.scss']
 })
-export class UserSettingsComponent implements OnInit {
+export class UserSettingsComponent implements OnInit, AfterContentInit {
 
   myCourses: ICourse[];
   displayedColumns = ['name', 'Notifications', 'email'];
@@ -33,6 +33,11 @@ export class UserSettingsComponent implements OnInit {
 
   ngOnInit() {
     this.getCourses();
+    this.getNotificationSettings().then(() => {
+      this.setSelection();
+    });
+  }
+    ngAfterContentInit(){
     this.getNotificationSettings().then(() => {
       this.setSelection();
     });

--- a/app/webFrontend/src/app/user/user-settings/user-settings.component.ts
+++ b/app/webFrontend/src/app/user/user-settings/user-settings.component.ts
@@ -38,10 +38,9 @@ export class UserSettingsComponent implements OnInit, AfterContentInit {
       this.setSelection();
     });
   }
-  ngAfterContentInit() {
-    this.getNotificationSettings().then(() => {
+  async ngAfterContentInit() {
+    await this.getNotificationSettings();
       this.setSelection();
-    });
   }
 
   getCourses() {


### PR DESCRIPTION
UserSettingsComponent now also implements the interface AfterContentInit, this way it can get the Notificationsettings even after a refresh of the page with f5.

## Description:
When refreshing the usersettings-page with f5, the notification and email checkboxes unchecked themselves.

Closes #622 

## Improvements
- the user-settings-component.ts now also implements the interface "AfterContentInit". With the method "ngAfterContentnit" the notificationsettings can be acquired even after a refresh with f5 is done.

## Known Issues:
_NONE_

------
_Remember to prefix your PR-Title with `⚠ WIP: ` if you still work on it.
If you have reached a final state, remove the prefix._
