### PR TITLE
⚠WIP: Bugfix/#612 course progress gone after reload

### DIFF
--- a/app/webFrontend/src/app/shared/services/data.service.ts
+++ b/app/webFrontend/src/app/shared/services/data.service.ts
@@ -63,9 +63,9 @@ export abstract class DataService {
       .toPromise();
   }
 
-  readSingleItem<T>(id: string): Promise<T> {
+  readSingleItem<T>(id: string, apiPath = this.apiPath): Promise<T> {
     return new Promise((resolve, reject) => {
-      this.backendService.get(this.apiPath + id)
+      this.backendService.get(apiPath + id)
         .subscribe(
           (responseItems: any) => {
             if (this.changeProps2Date) {

--- a/app/webFrontend/src/app/shared/services/data/progress.service.ts
+++ b/app/webFrontend/src/app/shared/services/data/progress.service.ts
@@ -9,8 +9,6 @@ export class ProgressService extends DataService {
   }
 
   async getUnitProgress<T>(unitId: string): Promise<T> {
-    // The readSingleItem method seems to always return an array. But we don't need an array, we should update
-    // the progress and not add another progress field
     const unitProgress = await this.readSingleItem<any[]>(unitId, this.apiPath + 'units/');
     return unitProgress.length > 0 ? unitProgress[0] : null;
   }

--- a/app/webFrontend/src/app/shared/services/data/progress.service.ts
+++ b/app/webFrontend/src/app/shared/services/data/progress.service.ts
@@ -8,12 +8,11 @@ export class ProgressService extends DataService {
     super('progress/', backendService);
   }
 
-  getUnitProgress(unitId: string) {
-    const originalApiPath = this.apiPath;
-    this.apiPath += 'units/';
-    const promise = this.readSingleItem(unitId);
-    this.apiPath = originalApiPath;
-    return promise;
+  async getUnitProgress<T>(unitId: string): Promise<T> {
+    // The readSingleItem method seems to always return an array. But we don't need an array, we should update
+    // the progress and not add another progress field
+    const unitProgress = await this.readSingleItem<any[]>(unitId, this.apiPath + 'units/');
+    return unitProgress.length > 0 ? unitProgress[0] : null;
   }
 
   getCourseProgress(courseId: string) {

--- a/app/webFrontend/src/app/unit/code-kata-unit/code-kata-unit.component.ts
+++ b/app/webFrontend/src/app/unit/code-kata-unit/code-kata-unit.component.ts
@@ -46,6 +46,15 @@ export class CodeKataComponent implements OnInit {
         this.progress = this.codeKataUnit.progressData;
       }
     }
+
+    this.applyProgressData();
+  }
+
+  async applyProgressData() {
+    const progress = await this.progressService.getUnitProgress<ICodeKataUnitProgress>(this.codeKataUnit._id);
+    if (progress) {
+      this.progress = progress;
+    }
   }
 
   ngAfterViewInit() {

--- a/app/webFrontend/src/app/unit/task-unit/task-unit.component.html
+++ b/app/webFrontend/src/app/unit/task-unit/task-unit.component.html
@@ -6,7 +6,7 @@
           [class.correct]="validationMode && answer.value"
           [class.incorrect]="validationMode && !answer.value">
 
-        <mat-checkbox [disabled]="validationMode" [(ngModel)]="progress.answers[task._id][answer._id]">
+        <mat-checkbox [disabled]="validationMode" *ngIf="progress.answers[task._id]" [(ngModel)]="progress.answers[task._id][answer._id]">
           <span class="answer-text">{{answer.text}}</span>
         </mat-checkbox>
       </li>

--- a/app/webFrontend/src/app/unit/task-unit/task-unit.component.ts
+++ b/app/webFrontend/src/app/unit/task-unit/task-unit.component.ts
@@ -33,6 +33,16 @@ export class TaskUnitComponent implements OnInit {
       this.progress = this.taskUnit.progressData;
     }
 
+    this.applyProgressData();
+    this.shuffleAnswers();
+  }
+
+  async applyProgressData() {
+    const progress = await this.progressService.getUnitProgress<ITaskUnitProgress>(this.taskUnit._id);
+    if (progress) {
+      this.progress = progress;
+    }
+
     if (!this.progress.answers) {
       this.resetProgressAnswers();
     } else {
@@ -49,7 +59,6 @@ export class TaskUnitComponent implements OnInit {
         }
       });
     }
-    this.shuffleAnswers();
   }
 
   resetProgressAnswers() {


### PR DESCRIPTION
## Description:


Closes #612, #591 

## Improvements
- The course progress is now restored after page reloads and multiple submits don't add each other up anymore

## Known Issues:

data.service.ts could use some refactoring (e.g. being able to pass an apiPath to the methods instead of having to change and reset the member variable)

## Questions:

Should the user code in the code-katas be saved in the progress table? Could lead to js-injection in the future.

------
_Remember to prefix your PR-Title with `⚠ WIP: ` if you still work on it.
If you have reached a final state, remove the prefix._
