### PR TITLE
⚠ WIP: Bugfix/#680-delete-lecture

### DIFF
--- a/api/src/controllers/LectureController.ts
+++ b/api/src/controllers/LectureController.ts
@@ -5,8 +5,7 @@ import passportJwtMiddleware from '../security/passportJwtMiddleware';
 import {Lecture} from '../models/Lecture';
 import {ILecture} from '../../../shared/models/ILecture';
 import {Course} from '../models/Course';
-import {Notification} from '../models/Notification';
-import {Unit} from "../models/units/Unit";
+import {Unit} from '../models/units/Unit';
 
 @JsonController('/lecture')
 @UseBefore(passportJwtMiddleware)

--- a/api/src/controllers/LectureController.ts
+++ b/api/src/controllers/LectureController.ts
@@ -133,14 +133,17 @@ export class LectureController {
       return Lecture.findById(id).then((l) => {
         const lectureObject = l.toObject();
         const unitInObject = lectureObject['units'];
-
-        return Unit.remove({ _id : { $in: unitInObject}}, function (err) {
+        if (unitInObject != null && unitInObject.length !== 0) {
+          return Unit.remove({_id: {$in: unitInObject}}, function (err) {
             if (err) {
               return false;
             } else {
               return true;
             }
-      });
+          });
+        } else {
+          return true;
+        }
     });
     }).then (() => {
       return Lecture.deleteOne({_id: id}, function (err) {

--- a/api/src/controllers/UnitController.ts
+++ b/api/src/controllers/UnitController.ts
@@ -174,17 +174,22 @@ export class UnitController {
   @Authorized(['teacher', 'admin'])
   @Delete('/:id')
   deleteUnit(@Param('id') id: string) {
-    return Unit.findById(id).then((unit) => {
-      if (!unit) {
-        throw new NotFoundError();
-      }
-
-      return Lecture.update({}, {$pull: {units: id}})
-        .then(() => unit.remove())
-        .then(() => {
-          return {result: true};
+      return Lecture.update({}, {$pull: {units: id}}, function (err, val) {
+        if (!err) {
+          return true;
+        } else {
+          return false;
+        }
+      }).then (() => {
+        return Unit.deleteOne({_id: id}, function (err) {
+          if (err) {
+            return false;
+          } else {
+            return true;
+          }
         });
-    });
+      }
+  );
   }
 
   protected pushToLecture(lectureId: string, unit: any) {


### PR DESCRIPTION
## Description:
- change the mongo query for delete the lecture of the course-lecture-array, removing the units of the lecture and removing the lecture itself

Closes #680 

## Improvements
- the teacher can now delete lectures without an error 
- the db won't be wasted with remaining units of a deleted task

## Known Issues:
_NONE_

------
_Remember to prefix your PR-Title with `⚠ WIP: ` if you still work on it.
If you have reached a final state, remove the prefix._
