### PR TITLE
feature/#711-remove-firstname-from-resend-activation feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Refactored or slightly altered various course & user related APIs. [#654](https://github.com/h-da/geli/issues/654) [#691](https://github.com/h-da/geli/issues/691)
+- Removed firstname from resend activation feature and change button positioning. [#711] (https://github.com/h-da/geli/issues/711)
 
 ### Fixed
 - Fixed wasteful course data usage via specialized course model interfaces. [#654](https://github.com/h-da/geli/issues/654)

--- a/api/src/controllers/AuthController.ts
+++ b/api/src/controllers/AuthController.ts
@@ -142,7 +142,6 @@ export class AuthController {
    * @apiName ActivationResend
    * @apiGroup Auth
    *
-   * @apiParam {string} firstname firstname of user which activation should be resend.
    * @apiParam {string} lastname lastname of user which activation should be resend.
    * @apiParam {string} uid matriculation number of user which activation should be resend.
    * @apiParam {string} email email the new activation should be sent to.
@@ -156,12 +155,11 @@ export class AuthController {
    */
   @Post('/activationresend')
   @OnUndefined(204)
-  async activationResend (@BodyParam('firstname') firstname: string,
-                                      @BodyParam('lastname') lastname: string,
+  async activationResend (@BodyParam('lastname') lastname: string,
                                       @BodyParam('uid') uid: string,
                                       @BodyParam('email') email: string,
                                       @Res() response: Response) {
-        const user = await User.findOne({'profile.firstName': firstname, 'profile.lastName': lastname, uid: uid, role: 'student'});
+        const user = await User.findOne({'profile.lastName': lastname, uid: uid, role: 'student'});
 
         if (!user) {
           throw new BadRequestError(errorCodes.errorCodes.user.userNotFound.code);

--- a/api/test/integration/auth.ts
+++ b/api/test/integration/auth.ts
@@ -159,8 +159,7 @@ describe('Auth', () => {
 
       const res = await chai.request(app)
         .post(`${BASE_URL}/activationresend`)
-        .send({'firstname': resendActivationUser.profile.firstName,
-          'lastname': resendActivationUser.profile.lastName,
+        .send({'lastname': resendActivationUser.profile.lastName,
           'uid': resendActivationUser.uid,
           'email': resendActivationUser.email })
         .catch(err => err.response);
@@ -176,8 +175,7 @@ describe('Auth', () => {
 
       const res = await chai.request(app)
         .post(`${BASE_URL}/activationresend`)
-        .send({'firstname': resendActivationUser.profile.firstName,
-          'lastname': resendActivationUser.profile.lastName,
+        .send({'lastname': resendActivationUser.profile.lastName,
           'uid': resendActivationUser.uid,
           'email': resendActivationUser.email })
         .catch(err => err.response);
@@ -196,8 +194,7 @@ describe('Auth', () => {
 
       const res = await chai.request(app)
         .post(`${BASE_URL}/activationresend`)
-        .send({'firstname': resendActivationUser.profile.firstName,
-          'lastname': resendActivationUser.profile.lastName,
+        .send({'lastname': resendActivationUser.profile.lastName,
           'uid': resendActivationUser.uid,
           'email': resendActivationUser.email })
         .catch(err => err.response);
@@ -218,8 +215,7 @@ describe('Auth', () => {
 
       const res = await chai.request(app)
         .post(`${BASE_URL}/activationresend`)
-        .send({'firstname': resendActivationUser.profile.firstName,
-          'lastname': resendActivationUser.profile.lastName,
+        .send({'lastname': resendActivationUser.profile.lastName,
           'uid': resendActivationUser.uid,
           'email': resendActivationUser.email })
         .catch(err => err.response);
@@ -236,8 +232,7 @@ describe('Auth', () => {
 
       const res = await chai.request(app)
         .post(`${BASE_URL}/activationresend`)
-        .send({'firstname': resendActivationUser.profile.firstName,
-          'lastname': resendActivationUser.profile.lastName,
+        .send({'lastname': resendActivationUser.profile.lastName,
           'uid': resendActivationUser.uid,
           'email': resendActivationUser.email })
         .catch(err => err.response);

--- a/app/webFrontend/src/app/auth/activation-resend/activation-resend.component.html
+++ b/app/webFrontend/src/app/auth/activation-resend/activation-resend.component.html
@@ -19,20 +19,6 @@
     <form name="form" (ngSubmit)="resendActivation()" [formGroup]="resendActivationForm">
       <div class="form-group" formGroupName="profile">
         <mat-form-field>
-          <input matInput formControlName="firstName"
-                 [placeholder]="'common.profile.firstName'|translate"/>
-          <div *ngIf="resendActivationForm.get('profile').get('firstName').touched">
-            <small *ngIf="resendActivationForm.get('profile').get('firstName').hasError('required')"
-                   class="text-danger">
-              {{'common.validation.required'|translate}}
-            </small>
-            <small *ngIf="resendActivationForm.get('profile').get('firstName').hasError('minlength')"
-                   class="text-danger" translate [translateParams]="{min:2}">
-              common.validation.minLength
-            </small>
-          </div>
-        </mat-form-field>
-        <mat-form-field>
           <input matInput formControlName="lastName"
                  [placeholder]="'common.profile.lastName'|translate"/>
           <div *ngIf="resendActivationForm.get('profile').get('lastName').touched">
@@ -86,9 +72,12 @@
       <button mat-raised-button color="primary" type="submit"
               [disabled]="loading || !resendActivationForm?.valid">{{'common.send'|translate}}
       </button>
-      <button mat-raised-button type="button" routerLink="/register" routerLinkActive="active">
+    </form>
+    <div class="bottom-buttons">
+      <button mat-button type="button" routerLink="/register" routerLinkActive="active">
         {{'auth.resendActivation.back'|translate}}
       </button>
-    </form>
+    </div>
+
   </mat-card-content>
 </mat-card>

--- a/app/webFrontend/src/app/auth/activation-resend/activation-resend.component.scss
+++ b/app/webFrontend/src/app/auth/activation-resend/activation-resend.component.scss
@@ -19,3 +19,7 @@
 #resendActivationFormError{
   margin-bottom: 20px;
 }
+
+.bottom-buttons{
+  margin-top: 20px;
+}

--- a/app/webFrontend/src/app/auth/activation-resend/activation-resend.component.ts
+++ b/app/webFrontend/src/app/auth/activation-resend/activation-resend.component.ts
@@ -22,7 +22,6 @@ export class ActivationResendComponent implements OnInit {
 
   private trimFormFields() {
 
-    this.resendActivationForm.value.profile.firstName = this.resendActivationForm.value.profile.firstName.trim();
     this.resendActivationForm.value.profile.lastName = this.resendActivationForm.value.profile.lastName.trim();
     this.resendActivationForm.value.uid = this.resendActivationForm.value.uid.trim();
     this.resendActivationForm.value.email = this.resendActivationForm.value.email.trim();
@@ -61,8 +60,8 @@ export class ActivationResendComponent implements OnInit {
     this.resendActivationForm.value.email = this.resendActivationForm.value.email.replace(/\s/g, '').toLowerCase();
     this.trimFormFields();
     try {
-     await this.authenticationService.resendActivation(this.resendActivationForm.value.profile.firstName,
-        this.resendActivationForm.value.profile.lastName, this.resendActivationForm.value.uid, this.resendActivationForm.value.email);
+     await this.authenticationService.resendActivation(this.resendActivationForm.value.profile.lastName,
+       this.resendActivationForm.value.uid, this.resendActivationForm.value.email);
      this.resendActivationDone = true;
     } catch (err) {
       this.handleError(err);
@@ -103,7 +102,6 @@ export class ActivationResendComponent implements OnInit {
   generateForm() {
     this.resendActivationForm = this.formBuilder.group({
       profile: this.formBuilder.group({
-        firstName: ['', Validators.compose([Validators.required, Validators.minLength(2)])],
         lastName: ['', Validators.compose([Validators.required, Validators.minLength(2)])],
       }),
       uid: ['', Validators.compose([Validators.required, this.validateMatriculationNumber.bind(this)])],

--- a/app/webFrontend/src/app/auth/register/register.component.html
+++ b/app/webFrontend/src/app/auth/register/register.component.html
@@ -93,17 +93,19 @@
       <button mat-raised-button color="primary" type="submit"
               [disabled]="loading || !registerForm?.valid">{{'common.register'|translate}}
       </button>
-      <button *ngIf="role == 'student'" mat-raised-button type="button" routerLink="/activation-resend" routerLinkActive="active">
+    </form>
+    <div class="bottom-buttons">
+      <button *ngIf="role == 'student'" mat-button type="button" routerLink="/activation-resend" routerLinkActive="active">
         {{'auth.registration.resendActivationButton'|translate}}
       </button>
-    </form>
 
-    <button mat-button *ngIf="role==='student'" (click)="changeRole('teacher')" class="pull-right">
-      {{'auth.registration.teacherRegistrationButton'|translate}}
-    </button>
+      <button mat-button *ngIf="role==='student'" (click)="changeRole('teacher')" class="pull-right">
+        {{'auth.registration.teacherRegistrationButton'|translate}}
+      </button>
 
-    <button mat-button *ngIf="role!=='student'" (click)="changeRole('student')" class="pull-right">
-      {{'common.back'|translate}}
-    </button>
+      <button mat-button *ngIf="role!=='student'" (click)="changeRole('student')" class="pull-right">
+        {{'common.back'|translate}}
+      </button>
+    </div>
   </mat-card-content>
 </mat-card>

--- a/app/webFrontend/src/app/auth/register/register.component.scss
+++ b/app/webFrontend/src/app/auth/register/register.component.scss
@@ -23,7 +23,7 @@
     }
   }
 
-  .pull-right{
-    margin-top: 7px;
+  .bottom-buttons{
+    margin-top: 20px;
   }
 }

--- a/app/webFrontend/src/app/shared/services/authentication.service.ts
+++ b/app/webFrontend/src/app/shared/services/authentication.service.ts
@@ -86,13 +86,12 @@ export class AuthenticationService {
 
   }
 
-  resendActivation(firstname: string, lastname: string, uid: string, email: string) {
+  resendActivation(lastname: string, uid: string, email: string) {
     return new Promise((resolve, reject) => {
 
       return this.http.post(
         AuthenticationService.API_URL + 'auth/activationresend',
-        {firstname: firstname,
-                lastname: lastname,
+        {lastname: lastname,
                 uid: uid,
                 email: email}
       )


### PR DESCRIPTION
## Description:
removed firstname from resend activation feature
changed button positioning on register page to get to activation resend


Closes #711 

## Improvements
- removed firstname from resend activation feature
- changed button positioning on register page to get to activation resend, so button doesnt look too important

## Known Issues:
_NONE_

------
_Remember to prefix your PR-Title with `⚠ WIP: ` if you still work on it.
If you have reached a final state, remove the prefix._
