### PR TITLE
bugfix/#713-geli-emailvalidator-at-register-and-activation-resend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Refactored or slightly altered various course & user related APIs. [#654](https://github.com/h-da/geli/issues/654) [#691](https://github.com/h-da/geli/issues/691)
+- Refactored register and resend activation to use geli email validator with top level domain check. [#713] (https://github.com/h-da/geli/issues/713)
 
 ### Fixed
 - Fixed wasteful course data usage via specialized course model interfaces. [#654](https://github.com/h-da/geli/issues/654)

--- a/app/webFrontend/src/app/auth/activation-resend/activation-resend.component.html
+++ b/app/webFrontend/src/app/auth/activation-resend/activation-resend.component.html
@@ -72,7 +72,7 @@
             </small>
             <small *ngIf="mailError" class="text-danger">{{mailError}}</small>
             <small
-              *ngIf="resendActivationForm.controls.email.hasError('email') && !resendActivationForm.controls.email.hasError('required')"
+              *ngIf="resendActivationForm.controls.email.hasError('emailValidator') && !resendActivationForm.controls.email.hasError('required')"
               class="text-danger">
               {{'common.validation.invalid'|translate}}
             </small>

--- a/app/webFrontend/src/app/auth/activation-resend/activation-resend.component.ts
+++ b/app/webFrontend/src/app/auth/activation-resend/activation-resend.component.ts
@@ -6,6 +6,7 @@ import {ShowProgressService} from '../../shared/services/show-progress.service';
 import {MatSnackBar} from '@angular/material';
 import {errorCodes} from '../../../../../../api/src/config/errorCodes';
 import {TitleService} from '../../shared/services/title.service';
+import {emailValidator} from '../../shared/validators/validators';
 
 @Component({
   selector: 'app-activation-resend',
@@ -107,7 +108,7 @@ export class ActivationResendComponent implements OnInit {
         lastName: ['', Validators.compose([Validators.required, Validators.minLength(2)])],
       }),
       uid: ['', Validators.compose([Validators.required, this.validateMatriculationNumber.bind(this)])],
-      email: ['', Validators.compose([Validators.required, Validators.email])]
+      email: ['', Validators.compose([Validators.required, emailValidator])]
     });
   }
 

--- a/app/webFrontend/src/app/auth/register/register.component.html
+++ b/app/webFrontend/src/app/auth/register/register.component.html
@@ -65,11 +65,11 @@
           </small>
           <small *ngIf="mailError" class="text-danger">{{mailError}}</small>
           <small
-            *ngIf="registerForm.controls.email.hasError('teacherEmailError') && !registerForm.controls.email.hasError('email') && !registerForm.controls.email.hasError('required')"
+            *ngIf="registerForm.controls.email.hasError('teacherEmailError') && !registerForm.controls.email.hasError('emailValidator') && !registerForm.controls.email.hasError('required')"
             class="text-danger">{{'common.validation.instituteMail'|translate}}
           </small>
           <small
-            *ngIf="registerForm.controls.email.hasError('email') && !registerForm.controls.email.hasError('teacherMailError') && !registerForm.controls.email.hasError('required')"
+            *ngIf="registerForm.controls.email.hasError('emailValidator') && !registerForm.controls.email.hasError('teacherMailError') && !registerForm.controls.email.hasError('required')"
             class="text-danger">
             {{'common.validation.invalid'|translate}}
           </small>

--- a/app/webFrontend/src/app/auth/register/register.component.ts
+++ b/app/webFrontend/src/app/auth/register/register.component.ts
@@ -112,7 +112,7 @@ export class RegisterComponent implements OnInit {
         firstName: ['', Validators.compose([Validators.required, Validators.minLength(2), Validators.maxLength(64)])],
         lastName: ['', Validators.compose([Validators.required, Validators.minLength(2), Validators.maxLength(64)])],
       }),
-      email: ['', Validators.compose([emailValidator, Validators.required, Validators.email, this.validateTeacherEmail.bind(this)])],
+      email: ['', Validators.compose([emailValidator, Validators.required, this.validateTeacherEmail.bind(this)])],
       uid: ['', [this.validateMatriculationNumber.bind(this)]]
     });
   }


### PR DESCRIPTION

## Description:
Refactored register and resend activation to use geli email validator with top level domain check

Closes #713 

## Improvements
- register and activation resend email input fields now use geli emailValidator with top level domain check

## Known Issues:
_NONE_

------
_Remember to prefix your PR-Title with `⚠ WIP: ` if you still work on it.
If you have reached a final state, remove the prefix._
