### PR TITLE
bugfix/#715-change-profile-progress-wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added an account activation resend feature. [#601](https://github.com/h-da/geli/issues/601)
 - Added `SnackBarService` as wrapper for `MatSnackBar`. [#574](https://github.com/h-da/geli/issues/574)
 - Added new course & user API unit tests. [#654](https://github.com/h-da/geli/issues/654) [#691](https://github.com/h-da/geli/issues/691)
-- Added details of courseAdmin and teacher to course detail view. on click profiles are shown.[#598] (https://github.com/h-da/geli/issues/598)
+- Added details of courseAdmin and teacher to course detail view. on click profiles are shown.[#598](https://github.com/h-da/geli/issues/598)
 - Added small auto linting scripts to package.json [#688](https://github.com/h-da/geli/issues/688)
 - Added changed size of drop down arrows for better usability. [#686] (https://github.com/h-da/geli/issues/686)
 
 ### Changed
 - Refactored or slightly altered various course & user related APIs. [#654](https://github.com/h-da/geli/issues/654) [#691](https://github.com/h-da/geli/issues/691)
 - Refactored the unitCreator with a forsafe user object. [#717](https://github.com/h-da/geli/pull/717)
-- Removed firstname from resend activation feature and change button positioning. [#711] (https://github.com/h-da/geli/issues/711)
-- Refactored register and resend activation to use geli email validator with top level domain check. [#713] (https://github.com/h-da/geli/issues/713)
+- Removed firstname from resend activation feature and change button positioning. [#711](https://github.com/h-da/geli/issues/711)
+- Refactored register and resend activation to use geli email validator with top level domain check. [#713](https://github.com/h-da/geli/issues/713)
 
 ### Fixed
 - Fixed Course progress mechanism
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Repair Angular CLI code generation. [#701](https://github.com/h-da/geli/pull/701)
 - Fixed `tsconfig.spec.ts` for `ng test`. [#656](https://github.com/h-da/geli/pull/656)
 - Fixed `.travis.yml`. [#706](https://github.com/h-da/geli/pull/706)
+- Fixed wording of progress display on profile page. [#715](https://github.com/h-da/geli/issues/715)
 
 ### Security
 - Fixed numerous severe user related security issues. [#691](https://github.com/h-da/geli/issues/691) [#709](https://github.com/h-da/geli/pull/709)

--- a/api/src/controllers/ReportController.ts
+++ b/api/src/controllers/ReportController.ts
@@ -577,9 +577,9 @@ export class ReportController {
       .map(({courseObj, progressableUnitCount}: any) => {
         const progressStats = this.calculateProgress(userProgressData, progressableUnitCount, courseObj);
         courseObj.progressData = [
-          { name: 'nothing', value: progressStats.nothing },
+          { name: 'not tried', value: progressStats.nothing },
           { name: 'tried', value: progressStats.tried },
-          { name: 'done', value: progressStats.done }
+          { name: 'solved', value: progressStats.done }
         ];
         return courseObj;
       })


### PR DESCRIPTION
Fixed wording of progress display on profile page to 'not triet', 'tried' and 'solved'

## Description:


Closes #715

## Improvements
- Adjusted wording at progress display on profile page for better understanding

## Known Issues:
_NONE_

------
_Remember to prefix your PR-Title with `⚠ WIP: ` if you still work on it.
If you have reached a final state, remove the prefix._
