### PR TITLE
Migrate MatSnackBar to SnackBarService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -->
 
 ## [NEXT] 
+### Changed
+- Migrate MatSnackBar to SnackBarService. [#724](https://github.com/h-da/geli/pull/724)
+- Reload user list after deleting an account. [#724](https://github.com/h-da/geli/pull/724)
+- Validate form before submit when creating a new course. [#724](https://github.com/h-da/geli/pull/724)
+- Validate :id for CourseController details route. [#724](https://github.com/h-da/geli/pull/724)
 
 ## [[0.7.0](https://github.com/h-da/geli/releases/tag/v0.7.0)] - 2018-05-05 - SS 18 intermediate Release
 ### Added

--- a/api/src/controllers/CourseController.ts
+++ b/api/src/controllers/CourseController.ts
@@ -162,7 +162,7 @@ export class CourseController {
    * @apiError NotFoundError Includes implicit authorization check. (In getCourse helper method.)
    * @apiError ForbiddenError (Redundant) Authorization check.
    */
-  @Get('/:id')
+  @Get('/:id([a-fA-F0-9]{24})')
   async getCourseView(@Param('id') id: string, @CurrentUser() currentUser: IUser): Promise<ICourseView> {
     const course = await this.getCourse(id, currentUser);
 

--- a/app/webFrontend/src/app/admin/user-admin/user-admin.component.ts
+++ b/app/webFrontend/src/app/admin/user-admin/user-admin.component.ts
@@ -2,7 +2,7 @@ import {Component, OnInit} from '@angular/core';
 import {UserDataService} from '../../shared/services/data.service';
 import {Router} from '@angular/router';
 import {ShowProgressService} from '../../shared/services/show-progress.service';
-import {MatSnackBar} from '@angular/material';
+import {SnackBarService} from '../../shared/services/snack-bar.service';
 import {IUser} from '../../../../../../shared/models/IUser';
 import {DialogService} from '../../shared/services/dialog.service';
 import {UserService} from '../../shared/services/user.service';
@@ -20,7 +20,7 @@ export class UserAdminComponent implements OnInit {
   constructor(private userDataService: UserDataService,
               private router: Router,
               private showProgress: ShowProgressService,
-              public  snackBar: MatSnackBar,
+              public  snackBar: SnackBarService,
               public  dialogService: DialogService,
               private userService: UserService) {
   }
@@ -46,18 +46,15 @@ export class UserAdminComponent implements OnInit {
     });
   }
 
-  updateRole(userIndex: number) {
+  async updateRole(userIndex: number) {
     this.showProgress.toggleLoadingGlobal(true);
-    this.userDataService.updateItem(this.allUsers[userIndex]).then(
-      (val) => {
-        this.showProgress.toggleLoadingGlobal(false);
-        this.snackBar.open('Role of user ' + val.email + ' successfully updated to ' + val.role, '', {duration: 3000});
-      },
-      (error) => {
-        this.snackBar.open(error.error.message, '', {duration: 3000});
-        this.showProgress.toggleLoadingGlobal(false);
-      }
-    );
+    try {
+      const user = await this.userDataService.updateItem(this.allUsers[userIndex]);
+      this.snackBar.open('Role of user ' + user.email + ' successfully updated to ' + user.role);
+    } catch (err) {
+      this.snackBar.open(err.error.message);
+    }
+    this.showProgress.toggleLoadingGlobal(false);
   }
 
   editUser(userIndex: number) {
@@ -66,22 +63,24 @@ export class UserAdminComponent implements OnInit {
   }
 
   deleteUser(userIndex: number) {
-    this.dialogService
-    .confirmDelete('user', this.allUsers[userIndex].email)
-    .subscribe(res => {
-      if (res) {
+    this.dialogService.confirmDelete('user', this.allUsers[userIndex].email)
+      .subscribe(async res => {
+        if (!res) {
+          return;
+        }
+
         this.showProgress.toggleLoadingGlobal(true);
-        this.userDataService.deleteItem(this.allUsers[userIndex]).then(
-          (val) => {
-            this.showProgress.toggleLoadingGlobal(false);
-            this.snackBar.open('User ' + val + ' was successfully deleted.', '', {duration: 3000});
-          },
-          (error) => {
-            this.showProgress.toggleLoadingGlobal(false);
-            this.snackBar.open(error, '', {duration: 3000});
-          }
-        );
-      }
+        const user = this.allUsers[userIndex];
+
+        try {
+          await this.userDataService.deleteItem(user);
+          this.snackBar.open('User ' + user.email + ' was successfully deleted.');
+        } catch (err) {
+          this.snackBar.open(err.error.message);
+        }
+
+        this.getUsers();
+        this.showProgress.toggleLoadingGlobal(false);
     });
   }
 }

--- a/app/webFrontend/src/app/auth/activation-resend/activation-resend.component.ts
+++ b/app/webFrontend/src/app/auth/activation-resend/activation-resend.component.ts
@@ -3,7 +3,7 @@ import {Validators, FormGroup, FormBuilder, FormControl} from '@angular/forms';
 import {AuthenticationService} from '../../shared/services/authentication.service';
 import {Router} from '@angular/router';
 import {ShowProgressService} from '../../shared/services/show-progress.service';
-import {MatSnackBar} from '@angular/material';
+import {SnackBarService} from '../../shared/services/snack-bar.service';
 import {errorCodes} from '../../../../../../api/src/config/errorCodes';
 import {TitleService} from '../../shared/services/title.service';
 import {emailValidator} from '../../shared/validators/validators';
@@ -32,7 +32,7 @@ export class ActivationResendComponent implements OnInit {
   constructor(private router: Router,
               private authenticationService: AuthenticationService,
               private showProgress: ShowProgressService,
-              private snackBar: MatSnackBar,
+              private snackBar: SnackBarService,
               private formBuilder: FormBuilder,
               private titleService: TitleService, ) {
   }
@@ -95,7 +95,7 @@ export class ActivationResendComponent implements OnInit {
         break;
       }
       default: {
-        this.snackBar.open('Activation Resend failed', 'Dismiss');
+        this.snackBar.open('Activation Resend failed');
       }
     }
   }

--- a/app/webFrontend/src/app/course/course-container/course-container.component.ts
+++ b/app/webFrontend/src/app/course/course-container/course-container.component.ts
@@ -1,5 +1,6 @@
 import {Component, EventEmitter, Input, Output, OnInit, ViewEncapsulation} from '@angular/core';
-import {MatDialog, MatSnackBar} from '@angular/material';
+import {MatDialog} from '@angular/material';
+import {SnackBarService} from '../../shared/services/snack-bar.service';
 import {UserService} from '../../shared/services/user.service';
 import {CourseService, UserDataService} from '../../shared/services/data.service';
 import {Router} from '@angular/router';
@@ -30,7 +31,7 @@ export class CourseContainerComponent implements OnInit {
               private courseService: CourseService,
               private router: Router,
               private dialog: MatDialog,
-              private snackBar: MatSnackBar,
+              private snackBar: SnackBarService,
               private userDataService: UserDataService) {
 
   }
@@ -48,22 +49,21 @@ export class CourseContainerComponent implements OnInit {
       accessKey
     }).then((res) => {
       LastVisitedCourseContainerUpdater.addCourseToLastVisitedCourses(courseId, this.userService, this.userDataService);
-      this.snackBar.open('Successfully enrolled', '', {duration: 5000});
+      this.snackBar.open('Successfully enrolled');
       // reload courses to update enrollment status
       this.onEnroll.emit();
-    }).catch((error) => {
-      const errormessage = error.error.message;
-      switch (errormessage) {
+    }).catch((err) => {
+      switch (err.error.message) {
         case errorCodes.course.accessKey.code: {
-          this.snackBar.open(`${errorCodes.course.accessKey.text}`, 'Dismiss');
+          this.snackBar.open(`${errorCodes.course.accessKey.text}`);
           break;
         }
         case errorCodes.course.notOnWhitelist.code: {
-          this.snackBar.open(`${errorCodes.course.notOnWhitelist.text}`, 'Dismiss');
+          this.snackBar.open(`${errorCodes.course.notOnWhitelist.text}`);
           break;
         }
         default: {
-          this.snackBar.open('Enroll failed', '', {duration: 5000});
+          this.snackBar.open('Enroll failed');
         }
       }
     });

--- a/app/webFrontend/src/app/course/course-detail/course-detail.component.ts
+++ b/app/webFrontend/src/app/course/course-detail/course-detail.component.ts
@@ -7,6 +7,7 @@ import {UserService} from '../../shared/services/user.service';
 import {IUser} from '../../../../../../shared/models/IUser';
 import {User} from '../../models/User';
 import {MatSnackBar, MatDialog} from '@angular/material';
+import {SnackBarService} from '../../shared/services/snack-bar.service';
 import {DownloadCourseDialogComponent} from './download-course-dialog/download-course-dialog.component';
 import {TitleService} from '../../shared/services/title.service';
 import {LastVisitedCourseContainerUpdater} from '../../shared/utils/LastVisitedCourseContainerUpdater';
@@ -27,7 +28,7 @@ export class CourseDetailComponent implements OnInit {
               private route: ActivatedRoute,
               private courseService: CourseService,
               public userService: UserService,
-              private snackBar: MatSnackBar,
+              private snackBar: SnackBarService,
               private dialog: MatDialog,
               private titleService: TitleService,
               private userDataService: UserDataService,
@@ -47,14 +48,12 @@ export class CourseDetailComponent implements OnInit {
       this.course = await this.courseService.readCourseToView(courseId);
       this.titleService.setTitleCut(['Course: ', this.course.name]);
       LastVisitedCourseContainerUpdater.addCourseToLastVisitedCourses(courseId, this.userService, this.userDataService);
-    } catch (errorResponse) {
-      if (errorResponse.status === 401) {
-        this.snackBar.open('You are not authorized to view this course.', '', {duration: 3000});
-      } else if (errorResponse.status === 404) {
-        this.snackBar.open('Your selected course is not available.', '', {duration: 3000});
+    } catch (err) {
+      if (err.status === 404) {
+        this.snackBar.open('Your selected course is not available.');
         this.router.navigate(['/not-found']);
       } else {
-        this.snackBar.open('Something went wrong: ' + errorResponse.message, '', {duration: 3000});
+        this.snackBar.open('Something went wrong: ' + err.error.message);
       }
     }
   }

--- a/app/webFrontend/src/app/course/course-detail/download-course-dialog/download-course-dialog.component.ts
+++ b/app/webFrontend/src/app/course/course-detail/download-course-dialog/download-course-dialog.component.ts
@@ -1,5 +1,6 @@
 import {Component, Inject, OnInit, QueryList, ViewChildren, ViewEncapsulation} from '@angular/core';
-import {MAT_DIALOG_DATA, MatDialog, MatDialogRef, MatSnackBar} from '@angular/material';
+import {MAT_DIALOG_DATA, MatDialog, MatDialogRef} from '@angular/material';
+import {SnackBarService} from '../../../shared/services/snack-bar.service';
 import {ICourse} from '../../../../../../../shared/models/ICourse';
 import {LectureCheckboxComponent} from './downloadCheckBoxes/lecture-checkbox.component';
 import {DownloadFileService} from 'app/shared/services/data.service';
@@ -28,7 +29,7 @@ export class DownloadCourseDialogComponent implements OnInit {
   constructor(public dialogRef: MatDialogRef<DownloadCourseDialogComponent>,
               @Inject(MAT_DIALOG_DATA) public data: any,
               private downloadReq: DownloadFileService,
-              public snackBar: MatSnackBar,
+              public snackBar: SnackBarService,
               private saveFileService: SaveFileService) {
   }
 
@@ -57,7 +58,7 @@ export class DownloadCourseDialogComponent implements OnInit {
   }
 
   onChildEvent() {
-    const childChecked: boolean[] = new Array();
+    const childChecked: boolean[] = [];
 
     this.childLectures.forEach(lec => {
       if (lec.chkbox === true && !lec.childUnits.find(unit => unit.chkbox === false)) {
@@ -109,7 +110,7 @@ export class DownloadCourseDialogComponent implements OnInit {
     this.disableDownloadButton = true;
     const obj = await this.buildObject();
     if (obj.lectures.length === 0) {
-      this.snackBar.open('No units selected!', 'Dismiss', {duration: 3000});
+      this.snackBar.open('No units selected!');
       this.disableDownloadButton = false;
       return;
     }
@@ -125,15 +126,13 @@ export class DownloadCourseDialogComponent implements OnInit {
         if (!this.keepDialogOpen) {
           this.dialogRef.close();
         }
-      } catch (error) {
+      } catch (err) {
         this.showSpinner = false;
         this.disableDownloadButton = false;
-        this.snackBar.open('Woops! Something went wrong. Please try again in a few Minutes.',
-          'Dismiss', {duration: 10000});
+        this.snackBar.openLong('Woops! Something went wrong. Please try again in a few Minutes.');
       }
     } else {
-      this.snackBar.open('Requested Download Package is too large! Please Download fewer Units in one Package.',
-        'Dismiss', {duration: 10000});
+      this.snackBar.openLong('Requested Download Package is too large! Please Download fewer Units in one Package.');
       this.showSpinner = false;
       this.disableDownloadButton = false;
     }
@@ -163,8 +162,7 @@ export class DownloadCourseDialogComponent implements OnInit {
       }
     });
 
-    const downloadObj = {courseName: this.course._id, lectures: lectures};
-    return downloadObj;
+    return  {courseName: this.course._id, lectures: lectures};
   }
 
 }

--- a/app/webFrontend/src/app/course/course-detail/download-course-dialog/downloadCheckBoxes/unit-checkbox.component.ts
+++ b/app/webFrontend/src/app/course/course-detail/download-course-dialog/downloadCheckBoxes/unit-checkbox.component.ts
@@ -5,7 +5,6 @@ import {
 import {IUnit} from '../../../../../../../../shared/models/units/IUnit';
 import {IFileUnit} from '../../../../../../../../shared/models/units/IFileUnit';
 import {UploadUnitCheckboxComponent} from './upload-unit-checkbox.component';
-import {MatSnackBar} from '@angular/material';
 import {ConfigService} from '../../../../shared/services/data.service';
 
 
@@ -32,7 +31,7 @@ export class UnitCheckboxComponent implements OnInit {
   childUnitDesc: string;
   showCheckBox = true; // false if the unit has only large files
 
-  constructor(public snackBar: MatSnackBar, private configService: ConfigService) {
+  constructor(private configService: ConfigService) {
   }
 
   ngOnInit() {

--- a/app/webFrontend/src/app/course/course-edit/course-user-list/course-user-list-overview/course-user-list-overview.component.ts
+++ b/app/webFrontend/src/app/course/course-edit/course-user-list/course-user-list-overview/course-user-list-overview.component.ts
@@ -1,7 +1,7 @@
 import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
 import {IUser} from '../../../../../../../../shared/models/IUser';
 import {DialogService} from '../../../../shared/services/dialog.service';
-import {MatSnackBar} from '@angular/material';
+import {SnackBarService} from '../../../../shared/services/snack-bar.service';
 import {CourseService, NotificationService} from '../../../../shared/services/data.service';
 import {ICourse} from '../../../../../../../../shared/models/ICourse';
 import {User} from '../../../../models/User';
@@ -27,7 +27,8 @@ export class CourseUserListOverviewComponent implements OnInit {
     return users.map((user: IUser) => `${user.profile.firstName} ${user.profile.lastName}<${user.email}>`).join(', ');
   }
 
-  constructor(private dialogService: DialogService, private snackBar: MatSnackBar,
+  constructor(private dialogService: DialogService,
+              private snackBar: SnackBarService,
               private courseService: CourseService,
               private notificationService: NotificationService) {
   }
@@ -84,9 +85,9 @@ export class CourseUserListOverviewComponent implements OnInit {
     this.resetSelectedUsers();
     try {
       await this.courseService.sendMailToSelectedUsers(mailData);
-      this.snackBar.open('Sending mail succeeded.', 'Dismiss', {duration: 2000});
+      this.snackBar.open('Sending mail succeeded.');
     } catch (err) {
-      this.snackBar.open('Sending mail failed.', 'Dismiss', {duration: 3000});
+      this.snackBar.open('Sending mail failed.');
     }
   }
 

--- a/app/webFrontend/src/app/course/course-edit/general-tab/general-tab.component.ts
+++ b/app/webFrontend/src/app/course/course-edit/general-tab/general-tab.component.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../../../../../shared/models/ICourse';
 import {ActivatedRoute, Router} from '@angular/router';
 import {CourseService, DuplicationService, ExportService, NotificationService} from '../../../shared/services/data.service';
-import {MatSnackBar} from '@angular/material';
+import {SnackBarService} from '../../../shared/services/snack-bar.service';
 import {ShowProgressService} from '../../../shared/services/show-progress.service';
 import {TitleService} from '../../../shared/services/title.service';
 import {SaveFileService} from '../../../shared/services/save-file.service';
@@ -48,7 +48,7 @@ export class GeneralTabComponent implements OnInit {
               private router: Router,
               private formBuilder: FormBuilder,
               private courseService: CourseService,
-              private snackBar: MatSnackBar,
+              private snackBar: SnackBarService,
               private ref: ChangeDetectorRef,
               private showProgress: ShowProgressService,
               private titleService: TitleService,
@@ -63,22 +63,21 @@ export class GeneralTabComponent implements OnInit {
     this.route.params.subscribe(params => {
       this.id = params['id'];
 
-      this.courseService.readCourseToEdit(this.id).then(
-        (val: any) => {
-          this.course = val.name;
-          this.description = val.description;
-          this.accessKey = val.accessKey;
-          this.active = val.active;
-          this.enrollType = val.enrollType;
-          if (this.enrollType === 'whitelist') {
-            this.mode = true;
-          }
-          this.courseOb = val;
-          this.dataSharingService.setDataForKey('course', this.courseOb);
-          this.titleService.setTitleCut(['Edit Course: ', this.course]);
-        }, (error) => {
-          this.snackBar.open('Couldn\'t load Course-Item', '', {duration: 3000});
-        });
+      this.courseService.readCourseToEdit(this.id).then(course => {
+        this.courseOb = course;
+
+        this.course = this.courseOb.name;
+        this.description = this.courseOb.description;
+        this.accessKey = this.courseOb.accessKey;
+        this.active = this.courseOb.active;
+        this.enrollType = this.courseOb.enrollType;
+        this.mode = (this.enrollType === 'whitelist');
+
+        this.dataSharingService.setDataForKey('course', this.courseOb);
+        this.titleService.setTitleCut(['Edit Course: ', this.course]);
+      }).catch(err => {
+        this.snackBar.open('Couldn\'t load Course-Item');
+      });
     });
   }
 
@@ -97,13 +96,13 @@ export class GeneralTabComponent implements OnInit {
     this.uploader.onCompleteItem = (item: any, response: any, status: any) => {
       if (status === 200) {
         const result = JSON.parse(response);
-        this.snackBar.open('Upload complete, there now are ' + result.newlength + ' whitelisted users!', '', {duration: 10000});
+        this.snackBar.openLong('Upload complete, there now are ' + result.newlength + ' whitelisted users!');
         setTimeout(() => {
           this.uploader.clearQueue();
         }, 3000);
       } else {
         const error = JSON.parse(response);
-        this.snackBar.open('Upload failed with status ' + status + ' message was: ' + error.message, '', {duration: 20000});
+        this.snackBar.openLong('Upload failed with status ' + status + ' message was: ' + error.message);
         setTimeout(() => {
           this.uploader.clearQueue();
         }, 6000);
@@ -143,10 +142,10 @@ export class GeneralTabComponent implements OnInit {
       });
 
       this.showProgress.toggleLoadingGlobal(false);
-      this.snackBar.open('Saved successfully', '', {duration: 5000});
+      this.snackBar.open('Saved successfully');
     } catch (err) {
       this.showProgress.toggleLoadingGlobal(false);
-      this.snackBar.open('Saving course failed ' + err.error.message, 'Dismiss');
+      this.snackBar.open('Saving course failed ' + err.error.message, );
     }
   }
 
@@ -155,7 +154,7 @@ export class GeneralTabComponent implements OnInit {
       const courseJSON = await this.exportService.exportCourse(this.courseOb);
       this.saveFileService.save(this.courseOb.name, JSON.stringify(courseJSON, null, 2));
     } catch (err) {
-      this.snackBar.open('Export course failed ' + err.error.message, 'Dismiss');
+      this.snackBar.open('Export course failed ' + err.error.message);
     }
   }
 
@@ -163,9 +162,9 @@ export class GeneralTabComponent implements OnInit {
     try {
       const course = await this.duplicationService.duplicateCourse(this.courseOb, this.userService.user);
       this.router.navigate(['course', course._id, 'edit']);
-      this.snackBar.open('Course successfully duplicated', '', {duration: 3000});
+      this.snackBar.open('Course successfully duplicated');
     } catch (err) {
-      this.snackBar.open('Duplication of the course failed ' + err.error.message, 'Dismiss');
+      this.snackBar.open('Duplication of the course failed ' + err.error.message);
     }
   }
 

--- a/app/webFrontend/src/app/course/course-new/course-new.component.html
+++ b/app/webFrontend/src/app/course/course-new/course-new.component.html
@@ -1,7 +1,7 @@
 <div class="center-both">
   <h1>Create Course</h1>
   <mat-card>
-    <form class="course-form" (ngSubmit)="createCourse()" [formGroup]="newCourse">
+    <form class="course-form" (ngSubmit)="newCourse.valid && createCourse()" [formGroup]="newCourse">
       <mat-form-field class="full-width">
         <input matInput formControlName="name" placeholder="Course Name">
         <div *ngIf="nameError">

--- a/app/webFrontend/src/app/course/course-new/course-new.component.ts
+++ b/app/webFrontend/src/app/course/course-new/course-new.component.ts
@@ -34,10 +34,10 @@ export class CourseNewComponent implements OnInit {
 
   createCourse() {
     this.resetErrors();
-    this.courseService.createItem(this.newCourse.value).then((val) => {
+    this.courseService.createItem(this.newCourse.value).then(val => {
       this.snackBar.open('Course created');
       this.router.navigate(['course', val._id, 'edit']);
-    }).catch((err) => {
+    }).catch(err => {
       if (err.error.message === errorCodes.course.duplicateName.code) {
         this.nameError = errorCodes.course.duplicateName.text;
       } else {

--- a/app/webFrontend/src/app/course/course-new/course-new.component.ts
+++ b/app/webFrontend/src/app/course/course-new/course-new.component.ts
@@ -1,7 +1,7 @@
 import {Component, OnInit} from '@angular/core';
 import {FormBuilder, FormGroup, Validators} from '@angular/forms';
 import {CourseService} from '../../shared/services/data.service';
-import {MatSnackBar} from '@angular/material';
+import {SnackBarService} from '../../shared/services/snack-bar.service';
 import {Router} from '@angular/router';
 import {errorCodes} from '../../../../../../api/src/config/errorCodes';
 import {TitleService} from '../../shared/services/title.service';
@@ -19,7 +19,7 @@ export class CourseNewComponent implements OnInit {
   constructor(private router: Router,
               private formBuilder: FormBuilder,
               private courseService: CourseService,
-              public snackBar: MatSnackBar,
+              private snackBar: SnackBarService,
               private titleService: TitleService) {
   }
 
@@ -34,17 +34,16 @@ export class CourseNewComponent implements OnInit {
 
   createCourse() {
     this.resetErrors();
-    this.courseService.createItem(this.newCourse.value).then(
-      (val) => {
-        this.snackBar.open('Course created', 'Dismiss', {duration: 5000});
-        this.router.navigate(['course', val._id, 'edit']);
-      }, (err) => {
-        if (err.error.message === errorCodes.course.duplicateName.code) {
-          this.nameError = errorCodes.course.duplicateName.text;
-        } else {
-          this.snackBar.open('Error creating course ' + err.error.message, 'Dismiss');
-        }
-      });
+    this.courseService.createItem(this.newCourse.value).then((val) => {
+      this.snackBar.open('Course created');
+      this.router.navigate(['course', val._id, 'edit']);
+    }).catch((err) => {
+      if (err.error.message === errorCodes.course.duplicateName.code) {
+        this.nameError = errorCodes.course.duplicateName.text;
+      } else {
+        this.snackBar.open('Error creating course ' + err.error.message);
+      }
+    });
   }
 
   generateForm() {

--- a/app/webFrontend/src/app/unit/task-unit/task-unit.component.ts
+++ b/app/webFrontend/src/app/unit/task-unit/task-unit.component.ts
@@ -1,5 +1,5 @@
 import {Component, OnInit, Input} from '@angular/core';
-import {MatSnackBar} from '@angular/material';
+import {SnackBarService} from '../../shared/services/snack-bar.service';
 import {ActivatedRoute} from '@angular/router';
 import {ProgressService} from '../../shared/services/data/progress.service';
 import {ITaskUnit} from '../../../../../../shared/models/units/ITaskUnit';
@@ -23,7 +23,7 @@ export class TaskUnitComponent implements OnInit {
 
   constructor(private route: ActivatedRoute,
               private progressService: ProgressService,
-              private snackBar: MatSnackBar) {
+              private snackBar: SnackBarService) {
   }
 
   ngOnInit() {
@@ -82,10 +82,10 @@ export class TaskUnitComponent implements OnInit {
       promise
         .then((savedProgress) => {
           this.progress = savedProgress;
-          this.snackBar.open('Progress has been saved', '', {duration: 3000});
+          this.snackBar.open('Progress has been saved');
         })
         .catch((err) => {
-          this.snackBar.open(`An error occurred: ${err.error.message}`, '', {duration: 3000});
+          this.snackBar.open(`An error occurred: ${err.error.message}`);
         });
     };
 


### PR DESCRIPTION
## Description:
Closes #574

Migrate MatSnackBar to SnackBarService. There are still some places with MatSnackBar around but its easier to migrate in small steps.

## Improvements
- Migrate MatSnackBar to SnackBarService
- Validate Form before submit when creating a new course
- Validate :id for CourseController details route
- Refresh user list after deleting a account

## Known Issues:
- There are still some places with MatSnackBar around
