### PR TITLE
Migrate MatSnackBar to SnackBarService #2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Reload user list after deleting an account. [#724](https://github.com/h-da/geli/pull/724)
 - Validate form before submit when creating a new course. [#724](https://github.com/h-da/geli/pull/724)
 - Validate :id for CourseController details route. [#724](https://github.com/h-da/geli/pull/724)
+- Another MatSnackBar to SnackBarService migration. [#730](https://github.com/h-da/geli/pull/730)
 
 ## [[0.7.0](https://github.com/h-da/geli/releases/tag/v0.7.0)] - 2018-05-05 - SS 18 intermediate Release
 ### Added

--- a/app/webFrontend/src/app/shared/components/admin-markdown-edit/admin-markdown-edit.component.ts
+++ b/app/webFrontend/src/app/shared/components/admin-markdown-edit/admin-markdown-edit.component.ts
@@ -3,7 +3,7 @@ import {IConfig} from '../../../../../../../shared/models/IConfig';
 import {ConfigService} from '../../services/data.service';
 import {MarkdownService} from '../../services/markdown.service';
 import {errorCodes} from '../../../../../../../api/src/config/errorCodes';
-import {MatSnackBar} from '@angular/material';
+import {SnackBarService} from '../../services/snack-bar.service';
 import {ActivatedRoute} from '@angular/router';
 
 @Component({
@@ -20,8 +20,9 @@ export class AdminMarkdownEditComponent implements OnInit {
 
   constructor(private service: ConfigService,
               private mdService: MarkdownService,
-              private snackBar: MatSnackBar,
-              private route: ActivatedRoute) { }
+              private snackBar: SnackBarService,
+              private route: ActivatedRoute) {
+  }
 
   ngOnInit() {
     this.route.queryParams.subscribe(params => {
@@ -39,15 +40,17 @@ export class AdminMarkdownEditComponent implements OnInit {
       this.text = '';
     }
   }
-  onSave(markdown: string ) {
+
+  async onSave(markdown: string) {
     try {
-      void this.service.updateItem({_id: this.type, data: markdown});
-      this.snackBar.open( this.headingType + ' saved', '', {duration: 3000});
-    } catch (error) {
-      this.snackBar.open(errorCodes.save.couldNotSaveImprint.text, '', {duration: 3000});
+      await this.service.updateItem({_id: this.type, data: markdown});
+      this.snackBar.open(this.headingType + ' saved');
+    } catch (err) {
+      this.snackBar.open(errorCodes.save.couldNotSaveImprint.text);
     }
     void this.loadConfig();
   }
+
   onCancel() {
     void this.loadConfig();
   }

--- a/app/webFrontend/src/app/shared/components/pick-media-dialog/pick-media-dialog.component.ts
+++ b/app/webFrontend/src/app/shared/components/pick-media-dialog/pick-media-dialog.component.ts
@@ -1,5 +1,6 @@
 import {Component, Inject, OnInit, ViewChild} from '@angular/core';
-import {MAT_DIALOG_DATA, MatDialogRef, MatSelectionList, MatSnackBar} from '@angular/material';
+import {MAT_DIALOG_DATA, MatDialogRef, MatSelectionList} from '@angular/material';
+import {SnackBarService} from '../../services/snack-bar.service';
 import {IFile} from '../../../../../../../shared/models/mediaManager/IFile';
 import {IDirectory} from '../../../../../../../shared/models/mediaManager/IDirectory';
 import {MediaService} from '../../services/data.service';
@@ -19,7 +20,7 @@ export class PickMediaDialog implements OnInit {
 
   constructor(private dialogRef: MatDialogRef<PickMediaDialog>,
               private mediaService: MediaService,
-              private snackBar: MatSnackBar,
+              private snackBar: SnackBarService,
               @Inject(MAT_DIALOG_DATA) public data: any) {
   }
 
@@ -38,7 +39,7 @@ export class PickMediaDialog implements OnInit {
 
   save(): void {
     if (this.selectedOptions.length === 0) {
-      this.snackBar.open('Please choose at least one file', '', {duration: 2000});
+      this.snackBar.open('Please choose at least one file');
       return;
     }
 
@@ -48,5 +49,4 @@ export class PickMediaDialog implements OnInit {
   cancel(): void {
     this.dialogRef.close(false);
   }
-
 }

--- a/app/webFrontend/src/app/shared/components/upload-dialog/upload-dialog.component.ts
+++ b/app/webFrontend/src/app/shared/components/upload-dialog/upload-dialog.component.ts
@@ -2,7 +2,7 @@ import {Component, Input, OnInit, ViewChild} from '@angular/core';
 import {FileItem, FileUploader} from 'ng2-file-upload';
 import {IUser} from '../../../../../../../shared/models/IUser';
 import {MatDialogRef, MatSnackBar} from '@angular/material';
-
+import {SnackBarService} from '../../services/snack-bar.service';
 
 @Component({
   selector: 'app-upload-dialog',
@@ -23,7 +23,7 @@ export class UploadDialog implements OnInit {
 
   constructor(
     public dialogRef: MatDialogRef<UploadDialog>,
-    private snackBar: MatSnackBar) { }
+    private snackBar: SnackBarService) {}
 
   ngOnInit() {
     this.uploader = new FileUploader({
@@ -62,7 +62,7 @@ export class UploadDialog implements OnInit {
         nativeVideo.play();
       })
       .catch(error => {
-        this.snackBar.open('Couldn\'t start webcam', '', {duration: 3000});
+        this.snackBar.open('Couldn\'t start webcam');
       });
     }
   }
@@ -123,7 +123,7 @@ export class UploadDialog implements OnInit {
     try {
       this.uploader.uploadAll();
     } catch (error) {
-      this.snackBar.open('An error occured during the Upload', '', { duration: 3000 });
+      this.snackBar.open('An error occured during the Upload');
     }
 
   }

--- a/app/webFrontend/src/app/shared/components/upload-form-dialog/upload-form-dialog.component.ts
+++ b/app/webFrontend/src/app/shared/components/upload-form-dialog/upload-form-dialog.component.ts
@@ -1,5 +1,6 @@
 import {Component, Inject, OnInit, ViewChild} from '@angular/core';
 import {MAT_DIALOG_DATA, MatDialogRef, MatSnackBar} from '@angular/material';
+import {SnackBarService} from '../../services/snack-bar.service';
 import {UploadDialog} from '../upload-dialog/upload-dialog.component';
 import {IFileUnit} from '../../../../../../../shared/models/units/IFileUnit';
 import {UploadFormComponent} from '../upload-form/upload-form.component';
@@ -18,7 +19,7 @@ export class UploadFormDialog implements OnInit {
   uploadPath: string;
 
   constructor(public dialogRef: MatDialogRef<UploadDialog>,
-              private snackBar: MatSnackBar,
+              private snackBar: SnackBarService,
               @Inject(MAT_DIALOG_DATA) public data: any) {
     this.uploadPath = this.uploadPathTmp + data.targetDir._id;
   }
@@ -31,15 +32,14 @@ export class UploadFormDialog implements OnInit {
 
   onAllUploaded() {
     this.dialogRef.close(true);
+    this.snackBar.open('All items uploaded!');
   }
 
   uploadAll() {
     this.uploadForm.fileUploader.uploadAll();
     this.uploadForm.onAllUploaded.subscribe(
-      result =>
-        this.onAllUploaded()
-      , error =>
-        this.snackBar.open('Could not upload files', '', {duration: 3000})
+      result => this.onAllUploaded(),
+      error => this.snackBar.open('Could not upload files')
     );
   }
 

--- a/app/webFrontend/src/app/shared/components/upload-form/upload-form.component.ts
+++ b/app/webFrontend/src/app/shared/components/upload-form/upload-form.component.ts
@@ -1,6 +1,6 @@
 import {Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges} from '@angular/core';
 import {FileUploader, FileUploaderOptions} from 'ng2-file-upload';
-import {MatSnackBar} from '@angular/material';
+import {SnackBarService} from '../../services/snack-bar.service';
 
 @Component({
   selector: 'app-upload-form',
@@ -40,7 +40,7 @@ export class UploadFormComponent implements OnInit, OnChanges {
   private updateUploadParams = false;
   private error = false;
 
-  constructor(private snackBar: MatSnackBar) {
+  constructor(private snackBar: SnackBarService) {
   }
 
   ngOnInit() {
@@ -61,7 +61,7 @@ export class UploadFormComponent implements OnInit, OnChanges {
     this.fileUploader.onCancelItem = (file) => {
       // set error true, so dialog is not closed automatically
       this.error = true;
-      this.snackBar.open(`upload cancelled for ${file._file.name}`, 'Dismiss');
+      this.snackBar.open(`upload cancelled for ${file._file.name}`);
     };
 
     this.fileUploader.onBuildItemForm = (fileItem: any, form: any) => {
@@ -81,7 +81,7 @@ export class UploadFormComponent implements OnInit, OnChanges {
     this.fileUploader.onCompleteAll = () => {
       if (!this.error && this.fileUploader.queue.length === 0) {
         this.onAllUploaded.emit();
-        this.snackBar.open('All items uploaded!', '', {duration: 3000});
+        this.snackBar.open('All items uploaded!');
       }
     };
 
@@ -113,7 +113,7 @@ export class UploadFormComponent implements OnInit, OnChanges {
       // reset the error state to try again later
       item.isError = false;
       item.isUploaded = false;
-      this.snackBar.open(`${item._file.name} failed to upload`, 'Dismiss');
+      this.snackBar.open(`${item._file.name} failed to upload`);
     };
   }
 
@@ -127,7 +127,7 @@ export class UploadFormComponent implements OnInit, OnChanges {
   clearQueue() {
     this.fileUploader.clearQueue();
     if (this.fileUploader.queue.length > 0) {
-      this.snackBar.open('Queue couldn\'t be cleared.', 'Dismiss');
+      this.snackBar.open('Queue couldn\'t be cleared.');
     } else {
       this.onFileSelectedChange.emit(false);
     }

--- a/app/webFrontend/src/app/shared/components/upload-form/upload-form.component.ts
+++ b/app/webFrontend/src/app/shared/components/upload-form/upload-form.component.ts
@@ -81,7 +81,6 @@ export class UploadFormComponent implements OnInit, OnChanges {
     this.fileUploader.onCompleteAll = () => {
       if (!this.error && this.fileUploader.queue.length === 0) {
         this.onAllUploaded.emit();
-        this.snackBar.open('All items uploaded!');
       }
     };
 


### PR DESCRIPTION
## Description:
Closes #574

Migrate MatSnackBar to SnackBarService. There are still some places with MatSnackBar around but its easier to migrate in small steps.

Again without additional issue. This pr is still related to #574 and i guess its easier to keep track when linked to the original issue.

## Improvements
- Migrate MatSnackBar to SnackBarService
- Refactor some places to async/await

## Known Issues:
- There are still some places with MatSnackBar around (but most of them should be gone withhin the next weeks because other teams an working on this places. e.g. big unit refactoring, whitelist user improvments, etc.)

