### PR TITLE
Repair notification settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Reload user list after deleting an account. [#724](https://github.com/h-da/geli/pull/724)
 - Validate form before submit when creating a new course. [#724](https://github.com/h-da/geli/pull/724)
 - Validate :id for CourseController details route. [#724](https://github.com/h-da/geli/pull/724)
+- `getNotificationSettings` does not create new notification settings. [#731](https://github.com/h-da/geli/issues/731)
+
+### Fixed
+- Fixed broken notification settings. [#731](https://github.com/h-da/geli/issues/731)
 
 ## [[0.7.0](https://github.com/h-da/geli/releases/tag/v0.7.0)] - 2018-05-05 - SS 18 intermediate Release
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Validate form before submit when creating a new course. [#724](https://github.com/h-da/geli/pull/724)
 - Validate :id for CourseController details route. [#724](https://github.com/h-da/geli/pull/724)
 - `getNotificationSettings` does not create new notification settings. [#731](https://github.com/h-da/geli/issues/731)
+- Remove `isCourseTeacherOrAdmin` and `isMemberOfCourse`from UserService. [#731](https://github.com/h-da/geli/issues/731)
 
 ### Fixed
 - Fixed broken notification settings. [#731](https://github.com/h-da/geli/issues/731)

--- a/app/webFrontend/src/app/models/NotificationSettings.ts
+++ b/app/webFrontend/src/app/models/NotificationSettings.ts
@@ -1,16 +1,16 @@
 import {INotificationSettings} from '../../../../../shared/models/INotificationSettings';
-import {ICourse} from '../../../../../shared/models/ICourse';
 import {IUser} from '../../../../../shared/models/IUser';
+import {ICourseDashboard} from '../../../../../shared/models/ICourseDashboard';
 
 export class NotificationSettings implements INotificationSettings {
 
   _id: any;
-  course: ICourse;
+  course: ICourseDashboard;
   user: IUser;
   notificationType: string;
   emailNotification: boolean;
 
-  constructor(user: IUser, course: ICourse) {
+  constructor(user: IUser, course: ICourseDashboard) {
     this.course = course;
     this.user = user;
   }

--- a/app/webFrontend/src/app/shared/services/user.service.ts
+++ b/app/webFrontend/src/app/shared/services/user.service.ts
@@ -44,23 +44,4 @@ export class UserService {
   isLoggedInUser(user: IUser): boolean {
     return this.user._id === user._id;
   }
-
-  isCourseTeacherOrAdmin(course: ICourse) {
-    if (this.isStudent()) {
-      return false;
-    }
-    if (this.isAdmin()) {
-      return true;
-    }
-
-    if (course.courseAdmin._id === this.user._id) {
-      return true;
-    }
-
-    return ( course.teachers.filter(teacher => teacher._id === this.user._id).length);
-  }
-
-  isMemberOfCourse(course: ICourse) {
-    return course.students.filter(obj => obj._id === this.user._id).length > 0;
-  }
 }

--- a/app/webFrontend/src/app/user/user-settings/user-settings.component.ts
+++ b/app/webFrontend/src/app/user/user-settings/user-settings.component.ts
@@ -1,129 +1,126 @@
 import {Component, OnInit} from '@angular/core';
 import {UserService} from '../../shared/services/user.service';
 import {CourseService, NotificationSettingsService} from '../../shared/services/data.service';
-import {ICourse} from '../../../../../../shared/models/ICourse';
-import {MatSnackBar, MatTableDataSource} from '@angular/material';
+import {MatTableDataSource} from '@angular/material';
+import {SnackBarService} from '../../shared/services/snack-bar.service';
 import {SelectionModel} from '@angular/cdk/collections';
 import {
-  INotificationSettings, NOTIFICATION_TYPE_ALL_CHANGES,
+  INotificationSettings,
+  NOTIFICATION_TYPE_ALL_CHANGES,
   NOTIFICATION_TYPE_NONE
 } from '../../../../../../shared/models/INotificationSettings';
 import {NotificationSettings} from '../../models/NotificationSettings';
-import {isNullOrUndefined} from 'util';
-import {AfterContentInit} from '@angular/core/src/metadata/lifecycle_hooks';
+import {ICourseDashboard} from '../../../../../../shared/models/ICourseDashboard';
 
 @Component({
   selector: 'app-user-settings',
   templateUrl: './user-settings.component.html',
   styleUrls: ['./user-settings.component.scss']
 })
-export class UserSettingsComponent implements OnInit, AfterContentInit {
+export class UserSettingsComponent implements OnInit {
 
-  myCourses: ICourse[];
+  myCourses: ICourseDashboard[];
   displayedColumns = ['name', 'Notifications', 'email'];
-  dataSource: MatTableDataSource<ICourse>;
-  notificationSelection = new SelectionModel<ICourse>(true, []);
-  emailSelection = new SelectionModel<ICourse>(true, []);
+  dataSource: MatTableDataSource<ICourseDashboard>;
+  notificationSelection = new SelectionModel<ICourseDashboard>(true, []);
+  emailSelection = new SelectionModel<ICourseDashboard>(true, []);
   notificationSettings: INotificationSettings[];
 
-  constructor(public userService: UserService,
-              public courseService: CourseService,
-              public notificationSettingsService: NotificationSettingsService,
-              public snackBar: MatSnackBar) {
+  constructor(private userService: UserService,
+              private courseService: CourseService,
+              private notificationSettingsService: NotificationSettingsService,
+              private snackBar: SnackBarService) {
   }
 
-  ngOnInit() {
-    this.getCourses();
-    this.getNotificationSettings().then(() => {
-      this.setSelection();
-    });
-  }
-  async ngAfterContentInit() {
+  async ngOnInit() {
+    await this.getCourses();
     await this.getNotificationSettings();
-      this.setSelection();
+    this.setSelection();
   }
 
-  getCourses() {
+  async getCourses() {
     this.myCourses = [];
-    this.courseService.readItems().then(courses => {
-      courses.forEach((course: ICourse) => {
-        if (this.userService.isMemberOfCourse(course)) {
-          this.myCourses.push(course);
-        }
-      });
-      this.dataSource = new MatTableDataSource<ICourse>(this.myCourses);
-    });
+    try {
+      this.myCourses = (await this.courseService.readItems<ICourseDashboard>())
+        .filter((course: ICourseDashboard) => course.userIsCourseMember);
+      this.dataSource = new MatTableDataSource<ICourseDashboard>(this.myCourses);
+    } catch (err) {
+      this.snackBar.open('Could not fetch courses');
+    }
   }
 
   async getNotificationSettings() {
-    const settings = await this.notificationSettingsService.getNotificationSettingsPerUser(this.userService.user);
-    if (settings.length <= 0) {
-        await Promise.all(this.myCourses.map(async (course) => {
-          const newSetting = await this.notificationSettingsService.createItem({user: this.userService.user, course: course});
-          settings.push(newSetting);
-        }));
-    }
-    this.notificationSettings = settings;
+    this.notificationSettings = await this.notificationSettingsService.getNotificationSettingsPerUser(this.userService.user);;
   }
 
   setSelection() {
-    if (this.notificationSettings) {
-      this.notificationSettings.forEach((setting: INotificationSettings) => {
-        const courseWithNotificationSettings = this.myCourses.find(x => x._id === setting.course._id);
-        if (courseWithNotificationSettings) {
-          if (setting.notificationType === NOTIFICATION_TYPE_ALL_CHANGES) {
-            this.notificationSelection.select(courseWithNotificationSettings);
-          }
-          if (setting.emailNotification) {
-            this.emailSelection.select(courseWithNotificationSettings);
-          }
-        }
-      });
+    if (!this.notificationSettings) {
+      return;
     }
+
+    this.notificationSettings.forEach((setting: INotificationSettings) => {
+      const course = this.myCourses.find(tmp => tmp._id === setting.course._id);
+
+      if (course === undefined) {
+        return;
+      }
+
+      if (setting.notificationType === NOTIFICATION_TYPE_ALL_CHANGES) {
+        this.notificationSelection.select(course);
+      }
+
+      if (setting.emailNotification) {
+        this.emailSelection.select(course);
+      }
+    });
   }
 
-  saveNotificationSettings() {
-    try {
-      this.myCourses.forEach(async course => {
-        let settings: INotificationSettings;
-        this.notificationSettings.forEach((x) => {
-          if (x.course._id === course._id) {
-            settings = x;
-          }
-        });
-        if (settings === null || settings === undefined) {
+  async saveNotificationSettings() {
+    const errors = [];
+
+    for (const course of this.myCourses) {
+      try {
+        let settings = this.notificationSettings.find(tmp => tmp.course._id === course._id);
+
+        if (settings === undefined) {
           settings = await this.notificationSettingsService.createItem(new NotificationSettings(this.userService.user, course));
           this.notificationSettings.push(settings);
         }
+
         if (this.notificationSelection.isSelected(course)) {
           settings.notificationType = NOTIFICATION_TYPE_ALL_CHANGES;
         } else {
           settings.notificationType = NOTIFICATION_TYPE_NONE;
         }
+
         if (this.emailSelection.isSelected(course)) {
           settings.emailNotification = true;
         } else {
           settings.emailNotification = false;
         }
+
         await this.notificationSettingsService.updateItem(settings);
-      });
-      this.snackBar.open('Notification settings updated successfully.', '', {duration: 3000});
-    } catch (error) {
-      this.snackBar.open(error.message, 'Dismiss');
+      } catch (err) {
+        if (errors.indexOf(err.error.message) === -1) {
+          errors.push(err.error.message);
+        }
+      }
+    }
+
+    if (errors.length === 0) {
+      this.snackBar.open('Notification settings updated successfully.');
+    } else {
+      this.snackBar.openLong('Failed to save notification settings: ' + errors.join(', '));
     }
   }
 
-  isAllSelected(selectionModel: SelectionModel<ICourse>) {
-    const numSelected = selectionModel.selected.length;
-    const numRows = this.dataSource.data.length;
-    return numSelected === numRows;
+  isAllSelected(selectionModel: SelectionModel<ICourseDashboard>) {
+    return selectionModel.selected.length === this.dataSource.data.length;
   }
 
-  masterToggle(selectionModel: SelectionModel<ICourse>) {
-    this.isAllSelected(selectionModel) ?
-      selectionModel.clear() :
-      this.dataSource.data.forEach(row => selectionModel.select(row));
+  masterToggle(selectionModel: SelectionModel<ICourseDashboard>) {
+    this.isAllSelected(selectionModel)
+      ? selectionModel.clear()
+      : this.dataSource.data.forEach(row => selectionModel.select(row));
   }
-
-
 }

--- a/app/webFrontend/src/app/user/user-settings/user-settings.component.ts
+++ b/app/webFrontend/src/app/user/user-settings/user-settings.component.ts
@@ -50,7 +50,7 @@ export class UserSettingsComponent implements OnInit {
   }
 
   async getNotificationSettings() {
-    this.notificationSettings = await this.notificationSettingsService.getNotificationSettingsPerUser(this.userService.user);;
+    this.notificationSettings = await this.notificationSettingsService.getNotificationSettingsPerUser(this.userService.user);
   }
 
   setSelection() {

--- a/shared/models/INotificationSettings.ts
+++ b/shared/models/INotificationSettings.ts
@@ -1,5 +1,5 @@
-import {ICourse} from './ICourse';
 import {IUser} from './IUser';
+import {ICourseDashboard} from './ICourseDashboard';
 
 export const NOTIFICATION_TYPE_NONE = 'none';
 export const NOTIFICATION_TYPE_CHANGES_WITH_RELATIONIONSHIP = 'relatedChanges';
@@ -12,9 +12,8 @@ export const NOTIFICATION_TYPES = [
 
 export interface INotificationSettings {
   _id: any;
-  course: ICourse;
+  course: ICourseDashboard;
   user: IUser;
   notificationType: string;
   emailNotification: boolean;
 }
-


### PR DESCRIPTION
## Description:

Closes #731 

Api endpoint getCourses returns ICourseDashboard instead ICourse since #654. As a result the students property is missing and notification settings are broken.

## Improvements
- Student can edit his notification settings
- Migrate ICourse to ICourseDashbaord
- Remove defunct `isCourseTeacherOrAdmin` and `isMemberOfCourse`
- Use awesome SnackBarService for Snackbars 😁 

## Known Issues:
- Some warnings in user-settings.component.html about missing or invalid attributes. Dont know howto fix them. 
