### PR TITLE
Remove fast-csv dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - Update chromedriver. [#1343](https://github.com/geli-lms/geli/pull/1343)
+- Remove unused dependency `fast-csv`. [#1352](https://github.com/geli-lms/geli/pull/1352)
 
 ## [0.8.6] - 2019-05-07 - WS 18/19 🏁-Release
 ### Added

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -804,15 +804,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "arguments-extended": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/arguments-extended/-/arguments-extended-0.0.3.tgz",
-      "integrity": "sha1-YQfkkX0OtvCk3WYyD8Fa/HLvSUY=",
-      "requires": {
-        "extended": "~0.0.3",
-        "is-extended": "~0.0.8"
-      }
-    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -854,16 +845,6 @@
       "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
       "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
       "dev": true
-    },
-    "array-extended": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/array-extended/-/array-extended-0.0.11.tgz",
-      "integrity": "sha1-1xRK50jek8pybxIQCdv/FibRZL0=",
-      "requires": {
-        "arguments-extended": "~0.0.3",
-        "extended": "~0.0.3",
-        "is-extended": "~0.0.3"
-      }
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -1709,8 +1690,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -1731,14 +1711,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1751,20 +1729,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -1879,8 +1854,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -1892,7 +1866,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -1907,7 +1880,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -1921,7 +1893,6 @@
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -2019,8 +1990,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -2032,7 +2002,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -2117,8 +2086,7 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -2154,7 +2122,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -2174,7 +2141,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -2203,13 +2169,11 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
@@ -2691,16 +2655,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "date-extended": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/date-extended/-/date-extended-0.0.6.tgz",
-      "integrity": "sha1-I4AtV90b94GIE/4MMuhRqG2iZ8k=",
-      "requires": {
-        "array-extended": "~0.0.3",
-        "extended": "~0.0.3",
-        "is-extended": "~0.0.3"
-      }
-    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -2742,11 +2696,6 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
-    },
-    "declare.js": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/declare.js/-/declare.js-0.0.8.tgz",
-      "integrity": "sha1-BHit/5VkwAT1Hfc9i8E0AZ0o3N4="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -3421,22 +3370,6 @@
         }
       }
     },
-    "extended": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/extended/-/extended-0.0.6.tgz",
-      "integrity": "sha1-f7i/e52uOXWG5IVwrP1kLHjlBmk=",
-      "requires": {
-        "extender": "~0.0.5"
-      }
-    },
-    "extender": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/extender/-/extender-0.0.10.tgz",
-      "integrity": "sha1-WJwHSCvmGhRgttgfnCSqZ+jzJM0=",
-      "requires": {
-        "declare.js": "~0.0.4"
-      }
-    },
     "extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
@@ -3540,18 +3473,6 @@
         "ansi-gray": "^0.1.1",
         "color-support": "^1.1.3",
         "time-stamp": "^1.0.0"
-      }
-    },
-    "fast-csv": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/fast-csv/-/fast-csv-2.5.0.tgz",
-      "integrity": "sha512-M/9ezLU9/uDwvDZTt9sNFJa0iLDUsbhYJwPtnE0D9MjeuB6DY9wRCyUPZta9iI6cSz5wBWGaUPL61QH8h92cNA==",
-      "requires": {
-        "extended": "0.0.6",
-        "is-extended": "0.0.10",
-        "object-extended": "0.0.7",
-        "safer-buffer": "^2.1.2",
-        "string-extended": "0.0.8"
       }
     },
     "fast-deep-equal": {
@@ -3801,8 +3722,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3823,14 +3743,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3843,20 +3761,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3971,8 +3886,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3984,7 +3898,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3999,7 +3912,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4013,7 +3925,6 @@
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4111,8 +4022,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4124,7 +4034,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4209,8 +4118,7 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4246,7 +4154,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4266,7 +4173,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4295,13 +4201,11 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -5459,14 +5363,6 @@
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
-    },
-    "is-extended": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/is-extended/-/is-extended-0.0.10.tgz",
-      "integrity": "sha1-JE4UDfdbscmjEG9BL/GC+1NKbWI=",
-      "requires": {
-        "extended": "~0.0.3"
-      }
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -7594,16 +7490,6 @@
         }
       }
     },
-    "object-extended": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/object-extended/-/object-extended-0.0.7.tgz",
-      "integrity": "sha1-hP0j9WsVWCrrPoiwXLVdJDLWijM=",
-      "requires": {
-        "array-extended": "~0.0.4",
-        "extended": "~0.0.3",
-        "is-extended": "~0.0.3"
-      }
-    },
     "object-keys": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
@@ -9448,17 +9334,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
-    },
-    "string-extended": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/string-extended/-/string-extended-0.0.8.tgz",
-      "integrity": "sha1-dBlX3/SHsCcqee7FpE8jnubxfM0=",
-      "requires": {
-        "array-extended": "~0.0.5",
-        "date-extended": "~0.0.3",
-        "extended": "~0.0.3",
-        "is-extended": "~0.0.3"
-      }
     },
     "string-width": {
       "version": "1.0.2",

--- a/api/package.json
+++ b/api/package.json
@@ -41,7 +41,6 @@
     "body-parser": "^1.19.0",
     "cookie": "^0.4.0",
     "express": "^4.17.1",
-    "fast-csv": "^2.5.0",
     "highlight.js": "^9.15.10",
     "html-pdf": "^2.2.0",
     "jsonwebtoken": "^8.5.1",


### PR DESCRIPTION
fast-csv was used to parse a csv with students from obs. Since https://github.com/geli-lms/geli/pull/819 the csv is parsed by the frontend.